### PR TITLE
Fix module for users

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,6 @@ module "example_team_rds" {
   db_engine_version         = "5.7"
   db_instance_class         = "db.t2.small"
   db_retention_period       = 10
-  db_port                   = 3306
   db_storage_type           = "io1"
   db_iops                   = "1000"
   db_vpc_security_group_ids = ["sg-7e8cf203", "sg-7e8cf203"]
@@ -44,7 +43,6 @@ module "example_team_rds" {
 | db_engine_version | The engine version to use | string | `10.4` | no |
 | db_instance_class | The instance type of the RDS instance | string | `db.t2.small` | no |
 | db_backup_retention_period | The days to retain backups. Must be 1 or greater to be a source for a Read Replica | string | - | yes
-| db_port | The port on which the DB accepts connections | string | - | no |
 | db_storage_type | One of standard (magnetic), gp2 (general purpose SSD), or io1 (provisioned IOPS SSD). | string | `gp2` | no |
 | db_iops | The amount of provisioned IOPS. Setting this implies a storage_type of io1 | string | `0` | ** Required if 'db_storage_type' is set to io1 ** |
 | db_vpc_security_group_ids | List of VPC security groups to associate | list | `["sg-7e8cf203", "sg-7e8cf203"]`| no |
@@ -74,6 +72,7 @@ https://ministryofjustice.github.io/technical-guidance/standards/documenting-inf
 | secret_access_key | Secret key for rds account |
 | rds_instance_endpoint | The connection endpoint in address:port format |
 | rds_instance_arn | The ARN of the RDS instance |
+| rds_instance_id | The RDS instance ID |
 | database_name | Name of the database |
 | database_username | Database Username |
 | database_password | Database Password |

--- a/example/main.tf
+++ b/example/main.tf
@@ -11,7 +11,6 @@
   db_engine_version           = "5.7.17"
   db_instance_class           = "db.t2.small"
   db_backup_retention_period  = 10
-  db_port                     = 3306
   db_storage_type             = "io1"
   db_iops                     = "1000"
   db_vpc_security_group_ids   = ["sg-7e8cf203", "sg-7e8cf203"]

--- a/main.tf
+++ b/main.tf
@@ -82,7 +82,6 @@ resource "aws_db_instance" "rds" {
     engine                      = "${var.db_engine}"
     engine_version              = "${var.db_engine_version}"
     instance_class              = "${var.db_instance_class}"
-    port                        = "${var.db_port}"
     name                        = "${var.application}${var.environment-name}"
     username                    = "${random_string.username.result}"
     password                    = "${random_string.password.result}"

--- a/output.tf
+++ b/output.tf
@@ -12,6 +12,11 @@ output "rds_instance_endpoint" {
     value       = "${aws_db_instance.rds.endpoint}"
 } 
 
+output "rds_instance_id" {
+    description = "The RDS instance ID."
+    value       = "${aws_db_instance.rds.id}"
+}
+
 output "rds_instance_arn" {
     description = "The ARN of the RDS instance"
     value       = "${aws_db_instance.rds.arn}"

--- a/variables.tf
+++ b/variables.tf
@@ -20,9 +20,6 @@ variable "db_instance_class" {
 variable "db_backup_retention_period" {
     description = "The days to retain backups. Must be 1 or greater to be a source for a Read Replica"
 }
-variable "db_port" {
-    description = "The port on which the DB accepts connections"
-}
 
 variable "db_storage_type" {
     description = "One of standard magnetic gp2 general purpose SSD or io1 provisioned IOPS SSD."


### PR DESCRIPTION
connects to ministryofjustice/cloud-platform#303

**WHAT** 
- Remove database port variable from README.md, variables.tf and main.tf
- Add RDS ID output 

**WHY**
- By removing database port, Terraform will use the standard depending on the database chosen. e.g. Postgres - 5432.
- Users want to output the RDS instance ID from the module and are unable to in the current module. 