### PR TITLE
Fixes and snapshot_identifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ cluster_state_bucket
 | db_storage_type | One of standard (magnetic), gp2 (general purpose SSD), or io1 (provisioned IOPS SSD). | string | `gp2` | no |
 | db_iops | The amount of provisioned IOPS. Setting this implies a storage_type of io1 | string | `0` | ** Required if 'db_storage_type' is set to io1 ** |
 | db_name | The name of the database to be created on the instance (if empty, it will be the generated random identifier) | string |  | no |
+| snapshot_identifier | Specifies whether or not to create this database from a snapshot. This correlates to the snapshot ID you'd find in the RDS console. | string | "" | no |
 
 | cluster_name | The name of the cluster (eg.: cloud-platform-live-0) | string | - | yes |
 | cluster_state_bucket | The name of the S3 bucket holding the terraform state for the cluster | string | - | yes |

--- a/main.tf
+++ b/main.tf
@@ -17,7 +17,7 @@ resource "random_id" "id" {
 
 locals {
   identifier = "cloud-platform-${random_id.id.hex}"
-  db_name    = "${var.db_name != "" ? var.db_name : "${random_id.id.hex}"}"
+  db_name    = "${var.db_name != "" ? var.db_name : "db${random_id.id.hex}"}"
 }
 
 resource "random_string" "username" {
@@ -101,7 +101,7 @@ resource "aws_db_instance" "rds" {
   iops                      = "${var.db_iops}"
   storage_encrypted         = true
   db_subnet_group_name      = "${aws_db_subnet_group.db_subnet.name}"
-  vpc_security_group_ids    = ["${aws_security_group.rds-sg.name}"]
+  vpc_security_group_ids    = ["${aws_security_group.rds-sg.id }"]
   kms_key_id                = "${aws_kms_key.kms.arn}"
   multi_az                  = true
   copy_tags_to_snapshot     = true

--- a/main.tf
+++ b/main.tf
@@ -105,6 +105,7 @@ resource "aws_db_instance" "rds" {
   kms_key_id                = "${aws_kms_key.kms.arn}"
   multi_az                  = true
   copy_tags_to_snapshot     = true
+  snapshot_identifier       = "${var.snapshot_identifier}"
 
   tags {
     business-unit          = "${var.business-unit}"

--- a/variables.tf
+++ b/variables.tf
@@ -63,3 +63,8 @@ variable "cluster_name" {
 variable "cluster_state_bucket" {
   description = "The name of the S3 bucket holding the terraform state for the cluster"
 }
+
+variable "snapshot_identifier" {
+  description = "Specifies whether or not to create this database from a snapshot. This correlates to the snapshot ID you'd find in the RDS console."
+  default     = ""
+}


### PR DESCRIPTION
- Prefix the default db name with `"db"` so that it always begins with a letter (PostgreSQL limitation)
- `vpc_security_group_ids` was wrongly given the security group name
- Introduce `snapshot_identifier` to allow creating a new instance from a snapshot.