### PR TITLE
Add RDS Instance address and port as an output

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ Some of the inputs are tags. All infrastructure resources need to be tagged acco
 | Name | Description |
 |------|-------------|
 | rds_instance_endpoint | The connection endpoint in address:port format |
+| rds_instance_address | The hostname of the RDS instance |
+| rds_instance_port | The database port |
 | database_name | Name of the database |
 | database_username | Database Username |
 | database_password | Database Password |

--- a/output.tf
+++ b/output.tf
@@ -3,6 +3,16 @@ output "rds_instance_endpoint" {
   value       = "${aws_db_instance.rds.endpoint}"
 }
 
+output "rds_instance_address" {
+  description = "The hostname of the RDS instance"
+  value       = "${aws_db_instance.rds.address}"
+}
+
+output "rds_instance_port" {
+  description = "The database port"
+  value       = "${aws_db_instance.rds.port}"
+}
+
 output "database_name" {
   description = "Name of the database"
   value       = "${aws_db_instance.rds.name}"


### PR DESCRIPTION
connects to ministryofjustice/cloud-platform#462

**WHAT**
- Add RDS instance address and port output
- Amend documentation to show new outputs available 

**WHY**
Prison Visits Booking team are looking to migrate their Ruby application onto the new cloud platform. The team would like a new output available on the module that has the host name without the port.