### PR TITLE
Remove leading slash from backend config

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -7,7 +7,7 @@ data "terraform_remote_state" "cluster" {
   config {
     bucket = "${var.cluster_state_bucket}"
     region = "eu-west-1"
-    key    = "/env:/${var.cluster_name}/terraform.tfstate"
+    key    = "env:/${var.cluster_name}/terraform.tfstate"
   }
 }
 


### PR DESCRIPTION
Terraform 0.11.10 complains about it