### PR TITLE
Specify only major version for postgres 10

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -41,8 +41,8 @@ variable "db_engine" {
 }
 
 variable "db_engine_version" {
-  description = "The engine version to use e.g. 10.4"
-  default     = "10.4"
+  description = "The engine version to use e.g. 10"
+  default     = "10"
 }
 
 variable "db_instance_class" {


### PR DESCRIPTION
Since `auto_minor_version_upgrade` is enabled (default) the instances will receive automatic patches and specifying a
minor version here causes terraform to want to downgrade when an automatic update is pushed to the db instances.