### PR TITLE
split main and rds example, took providers out of module

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,11 @@ module "example_team_rds" {
   is-production          = "false"
   environment-name       = "development"
   infrastructure-support = "example-team@digtal.justice.gov.uk"
-  aws_region             = "eu-west-2"
+
+  providers = {
+    # This can be either "aws.london" or "aws.ireland:
+    aws = "aws.london"
+  }
 }
 
 ```
@@ -49,8 +53,8 @@ module "example_team_rds" {
 | snapshot_identifier | Specifies whether or not to create this database from a snapshot. This correlates to the snapshot ID you'd find in the RDS console. | string | | no |
 | cluster_name | The name of the cluster (eg.: cloud-platform-live-0) | string | - | yes |
 | cluster_state_bucket | The name of the S3 bucket holding the terraform state for the cluster | string | - | yes |
-| aws_region | region into which the resource will be created | string | eu-west-2 | no 
-
+| providers | provider (and region) creating the resources |  arrays of string | default provider | no
+|
 
 ### Tags
 

--- a/example/main.tf
+++ b/example/main.tf
@@ -3,56 +3,15 @@ terraform {
 }
 
 provider "aws" {
+  region = "eu-west-2"
+}
+
+provider "aws" {
+  alias  = "london"
+  region = "eu-west-2"
+}
+
+provider "aws" {
+  alias  = "ireland"
   region = "eu-west-1"
-}
-
-/*
- * When using this module through the cloud-platform-environments, the following
- * two variables are automatically supplied by the pipeline.
- *
- */
-
-variable "cluster_name" {}
-
-variable "cluster_state_bucket" {}
-
-/*
- * Make sure that you use the latest version of the module by changing the
- * `ref=` value in the `source` attribute to the latest version listed on the
- * releases page of this repository.
- *
- */
-module "example_team_rds" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=4.0"
-  cluster_name           = "${var.cluster_name}"
-  cluster_state_bucket   = "${var.cluster_state_bucket}"
-  team_name              = "example-repo"
-  business-unit          = "example-bu"
-  application            = "exampleapp"
-  is-production          = "false"
-  environment-name       = "development"
-  infrastructure-support = "example-team@digtal.justice.gov.uk"
-  aws_region             = "eu-west-2"
-}
-
-resource "kubernetes_secret" "example_team_rds" {
-  metadata {
-    name      = "example-team-rds-instance-output"
-    namespace = "my-namespace"
-  }
-
-  data {
-    rds_instance_endpoint = "${module.example_team_rds.rds_instance_endpoint}"
-    database_name         = "${module.example_team_rds.database_name}"
-    database_username     = "${module.example_team_rds.database_username}"
-    database_password     = "${module.example_team_rds.database_password}"
-    rds_instance_address  = "${module.example_team_rds.rds_instance_address}"
-
-    /* You can replace all of the above with the following, if you prefer to
-     * use a single database URL value in your application code:
-     *
-     * url = "postgres://${module.example_team_rds.database_username}:${module.example_team_rds.database_password}@${module.example_team_rds.rds_instance_endpoint}/${module.example_team_rds.database_name}"
-     *
-     */
-  }
 }

--- a/example/rds.tf
+++ b/example/rds.tf
@@ -1,0 +1,57 @@
+/*
+ * When using this module through the cloud-platform-environments, the following
+ * two variables are automatically supplied by the pipeline.
+ *
+ */
+
+variable "cluster_name" {}
+
+variable "cluster_state_bucket" {}
+
+/*
+ * Make sure that you use the latest version of the module by changing the
+ * `ref=` value in the `source` attribute to the latest version listed on the
+ * releases page of this repository.
+ *
+ */
+module "example_team_rds" {
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=4.2"
+  cluster_name           = "${var.cluster_name}"
+  cluster_state_bucket   = "${var.cluster_state_bucket}"
+  team_name              = "example-repo"
+  business-unit          = "example-bu"
+  application            = "exampleapp"
+  is-production          = "false"
+  environment-name       = "development"
+  infrastructure-support = "example-team@digtal.justice.gov.uk"
+
+  # Deprecated from the version 4.2 of this module
+  #aws_region             = "eu-west-2"  
+
+  providers = {
+    # Can be either "aws.london" or "aws.london"
+    aws = "aws.london"
+  }
+}
+
+resource "kubernetes_secret" "example_team_rds" {
+  metadata {
+    name      = "example-team-rds-instance-output"
+    namespace = "my-namespace"
+  }
+
+  data {
+    rds_instance_endpoint = "${module.example_team_rds.rds_instance_endpoint}"
+    database_name         = "${module.example_team_rds.database_name}"
+    database_username     = "${module.example_team_rds.database_username}"
+    database_password     = "${module.example_team_rds.database_password}"
+    rds_instance_address  = "${module.example_team_rds.rds_instance_address}"
+
+    /* You can replace all of the above with the following, if you prefer to
+     * use a single database URL value in your application code:
+     *
+     * url = "postgres://${module.example_team_rds.database_username}:${module.example_team_rds.database_password}@${module.example_team_rds.rds_instance_endpoint}/${module.example_team_rds.database_name}"
+     *
+     */
+  }
+}

--- a/main.tf
+++ b/main.tf
@@ -1,10 +1,6 @@
 data "aws_caller_identity" "current" {}
 data "aws_region" "current" {}
 
-provider "aws" {
-  alias = "london"
-  region = "eu-west-2"
-}
 data "terraform_remote_state" "cluster" {
   backend = "s3"
 
@@ -35,7 +31,6 @@ resource "random_string" "password" {
 }
 
 resource "aws_kms_key" "kms" {
-  provider = "aws.london"
   description = "${local.identifier}"
 
   tags {
@@ -49,14 +44,11 @@ resource "aws_kms_key" "kms" {
 }
 
 resource "aws_kms_alias" "alias" {
-  provider = "aws.london"
   name          = "alias/${local.identifier}"
   target_key_id = "${aws_kms_key.kms.key_id}"
 }
 
 resource "aws_db_subnet_group" "db_subnet" {
-    provider = "aws.london"
-
   name       = "${local.identifier}"
   subnet_ids = ["${data.terraform_remote_state.cluster.internal_subnets_ids}"]
 
@@ -71,8 +63,6 @@ resource "aws_db_subnet_group" "db_subnet" {
 }
 
 resource "aws_security_group" "rds-sg" {
-    provider = "aws.london"
-
   name        = "${local.identifier}"
   description = "Allow all inbound traffic"
   vpc_id      = "${data.terraform_remote_state.cluster.vpc_id}"
@@ -97,8 +87,6 @@ resource "aws_security_group" "rds-sg" {
 }
 
 resource "aws_db_instance" "rds" {
-    provider = "aws.london"
-
   identifier                = "${local.identifier}"
   final_snapshot_identifier = "${local.identifier}-finalsnapshot"
   allocated_storage         = "${var.db_allocated_storage}"

--- a/variables.tf
+++ b/variables.tf
@@ -65,6 +65,7 @@ variable "db_name" {
   default     = ""
 }
 
+#Deprecated from v3.2
 variable "aws_region" {
   description = "Region into which the resource will be created."
   default     = "eu-west-2"


### PR DESCRIPTION
- example/main.tf became example/main.tf AND example/rds.tf
- took the providers out of the module, adding default `aws.london` and `aws.ireland`
- Updated Readme

