### PR TITLE
parameterize family in aws_db_parameter_group

### DIFF
--- a/example/rds.tf
+++ b/example/rds.tf
@@ -15,13 +15,14 @@ variable "cluster_state_bucket" {}
  *
  */
 module "example_team_rds" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=4.3"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=4.5"
   cluster_name           = "${var.cluster_name}"
   cluster_state_bucket   = "${var.cluster_state_bucket}"
   team_name              = "example-repo"
   business-unit          = "example-bu"
   application            = "exampleapp"
   is-production          = "false"
+  db_engine_version      = "9.6"                                                                        # change this postgres version as you see fit.
   environment-name       = "development"
   infrastructure-support = "example-team@digtal.justice.gov.uk"
   force_ssl              = "true"

--- a/main.tf
+++ b/main.tf
@@ -122,7 +122,8 @@ resource "aws_db_instance" "rds" {
 
 resource "aws_db_parameter_group" "custom_parameters" {
   name   = "${local.identifier}"
-  family = "postgres10"
+  #family should look like postgres9.4
+  family = "${var.db_engine}${var.db_engine_version}"
 
   parameter {
     name  = "rds.force_ssl"

--- a/main.tf
+++ b/main.tf
@@ -120,10 +120,17 @@ resource "aws_db_instance" "rds" {
   }
 }
 
+# Regex matching db_engine_version -> RDS postgres family
+# This transforms db_engine_version 9.x.y to 9.x and 10.x to 10
+locals {
+  familyPattern = "/^((9\\.(\\d+)|1[01])(\\.\\d+)?(\\.\\d+)?)$/"
+}
+
 resource "aws_db_parameter_group" "custom_parameters" {
-  name   = "${local.identifier}"
-  #family should look like postgres9.4
-  family = "${var.db_engine}${var.db_engine_version}"
+  name = "${local.identifier}"
+
+  # family should look like postgres9.4
+  family = "postgres${replace(var.db_engine_version, local.familyPattern, "$2")}"
 
   parameter {
     name  = "rds.force_ssl"

--- a/variables.tf
+++ b/variables.tf
@@ -42,7 +42,7 @@ variable "db_engine" {
 
 variable "db_engine_version" {
   description = "The engine version to use e.g. 10"
-  default     = "9.6"
+  default     = "10"
 }
 
 variable "db_instance_class" {

--- a/variables.tf
+++ b/variables.tf
@@ -42,7 +42,7 @@ variable "db_engine" {
 
 variable "db_engine_version" {
   description = "The engine version to use e.g. 10"
-  default     = "10"
+  default     = "9.6"
 }
 
 variable "db_instance_class" {
@@ -73,10 +73,4 @@ variable "allow_major_version_upgrade" {
 variable "force_ssl" {
   description = "Enforce SSL connections, set to true to enable"
   default     = "false"
-}
-
-#Deprecated from v3.2
-variable "aws_region" {
-  description = "Region into which the resource will be created."
-  default     = "eu-west-2"
 }


### PR DESCRIPTION
This replaces the hardcoded value of _family_ in the _aws_db_parameter_group_ resource.
The new value is the concatenation of _db_engine_ and _db_engine_version_. 

Output of `terraform plan` after change, with default values : 
```
  + module.example_team_rds.aws_db_parameter_group.custom_parameters
      id:                                <computed>
      arn:                               <computed>
      description:                       "Managed by Terraform"
      family:                            "postgres10"
      name:                              "rds-instance-blabla"
      name_prefix:                       <computed>
      parameter.#:                       "1"
      parameter.2349693848.apply_method: "immediate"
      parameter.2349693848.name:         "rds.force_ssl"
      parameter.2349693848.value:        "1"
```