### PR TITLE
Fix rds family

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ For more details, be sure to read [this example](example/rds.tf)
 | force_ssl | Enforce SSL connections | boolean | `false` | no |
 | snapshot_identifier | Specifies whether or not to create this database from a snapshot. This correlates to the snapshot ID you'd find in the RDS console. | string | | no |
 | providers | provider (and region) creating the resources |  arrays of string | default provider | no |
-| rds_family | rds configuration version | string | 10 | no  |
+| rds_family | rds configuration version | string | `postgres10` | no  |
 
 
 ### Tags

--- a/README.md
+++ b/README.md
@@ -33,8 +33,7 @@ module "example_team_rds" {
   is-production          = "false"
   environment-name       = "development"
   infrastructure-support = "example-team@digtal.justice.gov.uk"
-
-  rds_family             = "9.6"
+  rds_family             = "postgres10"
 
   providers = {
     # This can be either "aws.london" or "aws.ireland:

--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ module "example_team_rds" {
   environment-name       = "development"
   infrastructure-support = "example-team@digtal.justice.gov.uk"
 
+  rds_family             = "9.6"
+
   providers = {
     # This can be either "aws.london" or "aws.ireland:
     aws = "aws.london"
@@ -62,6 +64,8 @@ For more details, be sure to read [this example](example/rds.tf)
 | force_ssl | Enforce SSL connections | boolean | `false` | no |
 | snapshot_identifier | Specifies whether or not to create this database from a snapshot. This correlates to the snapshot ID you'd find in the RDS console. | string | | no |
 | providers | provider (and region) creating the resources |  arrays of string | default provider | no |
+| rds_family | rds configuration version | string | 10 | no  |
+
 
 ### Tags
 

--- a/example/rds.tf
+++ b/example/rds.tf
@@ -26,9 +26,10 @@ module "example_team_rds" {
   environment-name       = "development"
   infrastructure-support = "example-team@digtal.justice.gov.uk"
   force_ssl              = "true"
+
   # rds_family should be one of: postgres9.4, postgres9.5, postgres9.6, postgres10, postgres11
   # Pick the one that defines the postgres version the best
-  rds_family             = "postgres9.6" 
+  rds_family = "postgres9.6"
 
   # use "allow_major_version_upgrade" when upgrading the major version of an engine
   allow_major_version_upgrade = "true"

--- a/example/rds.tf
+++ b/example/rds.tf
@@ -22,7 +22,8 @@ module "example_team_rds" {
   business-unit          = "example-bu"
   application            = "exampleapp"
   is-production          = "false"
-  db_engine_version      = "10"                                                                         # change this postgres version as you see fit.
+  # change the postgres version as you see fit.
+  db_engine_version      = "10"                                                                        
   environment-name       = "development"
   infrastructure-support = "example-team@digtal.justice.gov.uk"
   force_ssl              = "true"

--- a/example/rds.tf
+++ b/example/rds.tf
@@ -26,6 +26,9 @@ module "example_team_rds" {
   environment-name       = "development"
   infrastructure-support = "example-team@digtal.justice.gov.uk"
   force_ssl              = "true"
+  # rds_family should be one of: postgres9.4, postgres9.5, postgres9.6, postgres10, postgres11
+  # Pick the one that defines the postgres version the best
+  rds_family             = "postgres9.6" 
 
   # use "allow_major_version_upgrade" when upgrading the major version of an engine
   allow_major_version_upgrade = "true"

--- a/example/rds.tf
+++ b/example/rds.tf
@@ -22,14 +22,14 @@ module "example_team_rds" {
   business-unit          = "example-bu"
   application            = "exampleapp"
   is-production          = "false"
-  db_engine_version      = "9.6"                                                                        # change this postgres version as you see fit.
+  db_engine_version      = "10"                                                                         # change this postgres version as you see fit.
   environment-name       = "development"
   infrastructure-support = "example-team@digtal.justice.gov.uk"
   force_ssl              = "true"
 
   # rds_family should be one of: postgres9.4, postgres9.5, postgres9.6, postgres10, postgres11
   # Pick the one that defines the postgres version the best
-  rds_family = "postgres9.6"
+  rds_family = "postgres10"
 
   # use "allow_major_version_upgrade" when upgrading the major version of an engine
   allow_major_version_upgrade = "true"

--- a/example/rds.tf
+++ b/example/rds.tf
@@ -15,13 +15,14 @@ variable "cluster_state_bucket" {}
  *
  */
 module "example_team_rds" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=4.3"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=4.5"
   cluster_name           = "${var.cluster_name}"
   cluster_state_bucket   = "${var.cluster_state_bucket}"
   team_name              = "example-repo"
   business-unit          = "example-bu"
   application            = "exampleapp"
   is-production          = "false"
+  db_engine_version      = "9.6"                                                                        # change this postgres version as you see fit.
   environment-name       = "development"
   infrastructure-support = "example-team@digtal.justice.gov.uk"
   force_ssl              = "true"

--- a/main.tf
+++ b/main.tf
@@ -122,7 +122,8 @@ resource "aws_db_instance" "rds" {
 
 resource "aws_db_parameter_group" "custom_parameters" {
   name   = "${local.identifier}"
-  family = "postgres10"
+  #family should look like postgres9.4
+  family = "${var.db_engine}${var.db_engine_version}"
 
   parameter {
     name  = "rds.force_ssl"

--- a/main.tf
+++ b/main.tf
@@ -120,7 +120,6 @@ resource "aws_db_instance" "rds" {
   }
 }
 
-
 resource "aws_db_parameter_group" "custom_parameters" {
   name   = "${local.identifier}"
   family = "${var.rds_family}"

--- a/main.tf
+++ b/main.tf
@@ -120,17 +120,10 @@ resource "aws_db_instance" "rds" {
   }
 }
 
-# Regex matching db_engine_version -> RDS postgres family
-# This transforms db_engine_version 9.x.y to 9.x and 10.x to 10
-locals {
-  familyPattern = "/^((9\\.(\\d+)|1[01])(\\.\\d+)?(\\.\\d+)?)$/"
-}
 
 resource "aws_db_parameter_group" "custom_parameters" {
-  name = "${local.identifier}"
-
-  # family should look like postgres9.4
-  family = "postgres${replace(var.db_engine_version, local.familyPattern, "$2")}"
+  name   = "${local.identifier}"
+  family = "${var.rds_family}"
 
   parameter {
     name  = "rds.force_ssl"

--- a/main.tf
+++ b/main.tf
@@ -120,10 +120,17 @@ resource "aws_db_instance" "rds" {
   }
 }
 
+# Regex matching db_engine_version -> RDS postgres family
+# This transforms db_engine_version 9.x.y to 9.x and 10.x to 10
+locals {
+  familyPattern = "/^((9\\.(\\d+)|1[01])(\\.\\d+)?(\\.\\d+)?)$/"
+}
+
 resource "aws_db_parameter_group" "custom_parameters" {
-  name   = "${local.identifier}"
-  #family should look like postgres9.4
-  family = "${var.db_engine}${var.db_engine_version}"
+  name = "${local.identifier}"
+
+  # family should look like postgres9.4
+  family = "postgres${replace(var.db_engine_version, local.familyPattern, "$2")}"
 
   parameter {
     name  = "rds.force_ssl"

--- a/variables.tf
+++ b/variables.tf
@@ -42,7 +42,7 @@ variable "db_engine" {
 
 variable "db_engine_version" {
   description = "The engine version to use e.g. 10"
-  default     = "9.6"
+  default     = "10"
 }
 
 variable "db_instance_class" {

--- a/variables.tf
+++ b/variables.tf
@@ -74,3 +74,9 @@ variable "force_ssl" {
   description = "Enforce SSL connections, set to true to enable"
   default     = "false"
 }
+
+variable "rds_family" {
+  description = "Maps the postgres version with the rds family, a family often covers several versions"
+  default = "postgres10"
+}
+

--- a/variables.tf
+++ b/variables.tf
@@ -42,7 +42,7 @@ variable "db_engine" {
 
 variable "db_engine_version" {
   description = "The engine version to use e.g. 10"
-  default     = "10"
+  default     = "9.6"
 }
 
 variable "db_instance_class" {
@@ -73,10 +73,4 @@ variable "allow_major_version_upgrade" {
 variable "force_ssl" {
   description = "Enforce SSL connections, set to true to enable"
   default     = "false"
-}
-
-#Deprecated from v3.2
-variable "aws_region" {
-  description = "Region into which the resource will be created."
-  default     = "eu-west-2"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -77,6 +77,5 @@ variable "force_ssl" {
 
 variable "rds_family" {
   description = "Maps the postgres version with the rds family, a family often covers several versions"
-  default = "postgres10"
+  default     = "postgres10"
 }
-


### PR DESCRIPTION
This PR went through 2 complete rework.

- it introduced the `rds_family` variable
- `rds_family` is used by the `aws_db_parameter_group` resource
- Users are now expected to choose a family when invoking the module
- Readme Updated

