### PR TITLE
Terraform 0.12 upgrade

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,11 +1,12 @@
 data "aws_caller_identity" "current" {}
+
 data "aws_region" "current" {}
 
 data "terraform_remote_state" "cluster" {
   backend = "s3"
 
-  config {
-    bucket = "${var.cluster_state_bucket}"
+  config = {
+    bucket = var.cluster_state_bucket
     region = "eu-west-1"
     key    = "cloud-platform/${var.cluster_name}/terraform.tfstate"
   }
@@ -17,7 +18,7 @@ resource "random_id" "id" {
 
 locals {
   identifier = "cloud-platform-${random_id.id.hex}"
-  db_name    = "${var.db_name != "" ? var.db_name : "db${random_id.id.hex}"}"
+  db_name    = var.db_name != "" ? var.db_name : "db${random_id.id.hex}"
 }
 
 resource "random_string" "username" {
@@ -31,41 +32,41 @@ resource "random_string" "password" {
 }
 
 resource "aws_kms_key" "kms" {
-  description = "${local.identifier}"
+  description = local.identifier
 
-  tags {
-    business-unit          = "${var.business-unit}"
-    application            = "${var.application}"
-    is-production          = "${var.is-production}"
-    environment-name       = "${var.environment-name}"
-    owner                  = "${var.team_name}"
-    infrastructure-support = "${var.infrastructure-support}"
+  tags = {
+    business-unit          = var.business-unit
+    application            = var.application
+    is-production          = var.is-production
+    environment-name       = var.environment-name
+    owner                  = var.team_name
+    infrastructure-support = var.infrastructure-support
   }
 }
 
 resource "aws_kms_alias" "alias" {
   name          = "alias/${local.identifier}"
-  target_key_id = "${aws_kms_key.kms.key_id}"
+  target_key_id = aws_kms_key.kms.key_id
 }
 
 resource "aws_db_subnet_group" "db_subnet" {
-  name       = "${local.identifier}"
-  subnet_ids = ["${data.terraform_remote_state.cluster.internal_subnets_ids}"]
+  name       = local.identifier
+  subnet_ids = data.terraform_remote_state.cluster.outputs.internal_subnets_ids
 
-  tags {
-    business-unit          = "${var.business-unit}"
-    application            = "${var.application}"
-    is-production          = "${var.is-production}"
-    environment-name       = "${var.environment-name}"
-    owner                  = "${var.team_name}"
-    infrastructure-support = "${var.infrastructure-support}"
+  tags = {
+    business-unit          = var.business-unit
+    application            = var.application
+    is-production          = var.is-production
+    environment-name       = var.environment-name
+    owner                  = var.team_name
+    infrastructure-support = var.infrastructure-support
   }
 }
 
 resource "aws_security_group" "rds-sg" {
-  name        = "${local.identifier}"
+  name        = local.identifier
   description = "Allow all inbound traffic"
-  vpc_id      = "${data.terraform_remote_state.cluster.vpc_id}"
+  vpc_id      = data.terraform_remote_state.cluster.outputs.vpc_id
 
   // We cannot use `${aws_db_instance.rds.port}` here because it creates a
   // cyclic dependency. Rather than resorting to `aws_security_group_rule` which
@@ -75,59 +76,59 @@ resource "aws_security_group" "rds-sg" {
     from_port   = 0
     to_port     = 0
     protocol    = "-1"
-    cidr_blocks = ["${data.terraform_remote_state.cluster.internal_subnets}"]
+    cidr_blocks = data.terraform_remote_state.cluster.outputs.internal_subnets
   }
 
   egress {
     from_port   = 0
     to_port     = 0
     protocol    = "-1"
-    cidr_blocks = ["${data.terraform_remote_state.cluster.internal_subnets}"]
+    cidr_blocks = data.terraform_remote_state.cluster.outputs.internal_subnets
   }
 }
 
 resource "aws_db_instance" "rds" {
-  identifier                  = "${local.identifier}"
+  identifier                  = local.identifier
   final_snapshot_identifier   = "${local.identifier}-finalsnapshot"
-  allocated_storage           = "${var.db_allocated_storage}"
+  allocated_storage           = var.db_allocated_storage
   apply_immediately           = true
-  engine                      = "${var.db_engine}"
-  engine_version              = "${var.db_engine_version}"
-  instance_class              = "${var.db_instance_class}"
-  name                        = "${local.db_name}"
+  engine                      = var.db_engine
+  engine_version              = var.db_engine_version
+  instance_class              = var.db_instance_class
+  name                        = local.db_name
   username                    = "cp${random_string.username.result}"
-  password                    = "${random_string.password.result}"
-  backup_retention_period     = "${var.db_backup_retention_period}"
-  storage_type                = "${var.db_iops == 0 ? "gp2" : "io1" }"
-  iops                        = "${var.db_iops}"
+  password                    = random_string.password.result
+  backup_retention_period     = var.db_backup_retention_period
+  storage_type                = var.db_iops == 0 ? "gp2" : "io1"
+  iops                        = var.db_iops
   storage_encrypted           = true
-  db_subnet_group_name        = "${aws_db_subnet_group.db_subnet.name}"
-  vpc_security_group_ids      = ["${aws_security_group.rds-sg.id }"]
-  kms_key_id                  = "${aws_kms_key.kms.arn}"
+  db_subnet_group_name        = aws_db_subnet_group.db_subnet.name
+  vpc_security_group_ids      = [aws_security_group.rds-sg.id]
+  kms_key_id                  = aws_kms_key.kms.arn
   multi_az                    = true
   copy_tags_to_snapshot       = true
-  snapshot_identifier         = "${var.snapshot_identifier}"
-  allow_major_version_upgrade = "${var.allow_major_version_upgrade}"
-  parameter_group_name        = "${aws_db_parameter_group.custom_parameters.name}"
+  snapshot_identifier         = var.snapshot_identifier
+  allow_major_version_upgrade = var.allow_major_version_upgrade
+  parameter_group_name        = aws_db_parameter_group.custom_parameters.name
 
-  tags {
-    business-unit          = "${var.business-unit}"
-    application            = "${var.application}"
-    is-production          = "${var.is-production}"
-    environment-name       = "${var.environment-name}"
-    owner                  = "${var.team_name}"
-    infrastructure-support = "${var.infrastructure-support}"
+  tags = {
+    business-unit          = var.business-unit
+    application            = var.application
+    is-production          = var.is-production
+    environment-name       = var.environment-name
+    owner                  = var.team_name
+    infrastructure-support = var.infrastructure-support
   }
 }
 
 resource "aws_db_parameter_group" "custom_parameters" {
-  name   = "${local.identifier}"
-  family = "${var.rds_family}"
+  name   = local.identifier
+  family = var.rds_family
 
   parameter {
     name         = "rds.force_ssl"
-    value        = "${var.force_ssl ? 1 : 0}"
-    apply_method = "${var.apply_method}"
+    value        = var.force_ssl ? 1 : 0
+    apply_method = var.apply_method
   }
 }
 
@@ -137,7 +138,7 @@ resource "aws_iam_user" "user" {
 }
 
 resource "aws_iam_access_key" "user" {
-  user = "${aws_iam_user.user.name}"
+  user = aws_iam_user.user.name
 }
 
 data "aws_iam_policy_document" "policy" {
@@ -154,7 +155,7 @@ data "aws_iam_policy_document" "policy" {
     ]
 
     resources = [
-      "${aws_db_instance.rds.arn}",
+      aws_db_instance.rds.arn,
       "arn:aws:rds:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:snapshot:*",
     ]
   }
@@ -162,6 +163,7 @@ data "aws_iam_policy_document" "policy" {
 
 resource "aws_iam_user_policy" "policy" {
   name   = "rds-snapshots-read-write"
-  policy = "${data.aws_iam_policy_document.policy.json}"
-  user   = "${aws_iam_user.user.name}"
+  policy = data.aws_iam_policy_document.policy.json
+  user   = aws_iam_user.user.name
 }
+

--- a/output.tf
+++ b/output.tf
@@ -1,39 +1,39 @@
 output "rds_instance_endpoint" {
   description = "The connection endpoint in address:port format"
-  value       = "${aws_db_instance.rds.endpoint}"
+  value       = aws_db_instance.rds.endpoint
 }
 
 output "rds_instance_address" {
   description = "The hostname of the RDS instance"
-  value       = "${aws_db_instance.rds.address}"
+  value       = aws_db_instance.rds.address
 }
 
 output "rds_instance_port" {
   description = "The database port"
-  value       = "${aws_db_instance.rds.port}"
+  value       = aws_db_instance.rds.port
 }
 
 output "database_name" {
   description = "Name of the database"
-  value       = "${aws_db_instance.rds.name}"
+  value       = aws_db_instance.rds.name
 }
 
 output "database_username" {
   description = "Database Username"
-  value       = "${aws_db_instance.rds.username}"
+  value       = aws_db_instance.rds.username
 }
 
 output "database_password" {
   description = "Database Password"
-  value       = "${aws_db_instance.rds.password}"
+  value       = aws_db_instance.rds.password
 }
 
 output "access_key_id" {
   description = "Access key id for RDS IAM user"
-  value       = "${aws_iam_access_key.user.id}"
+  value       = aws_iam_access_key.user.id
 }
 
 output "secret_access_key" {
   description = "Secret key for RDS IAM user"
-  value       = "${aws_iam_access_key.user.secret}"
+  value       = aws_iam_access_key.user.secret
 }

--- a/variables.tf
+++ b/variables.tf
@@ -57,7 +57,8 @@ variable "db_backup_retention_period" {
 
 variable "db_iops" {
   description = "The amount of provisioned IOPS. Setting this to a value other than 0 implies a storage_type of io1"
-  default     = "0"
+  default     = 0
+  type        = number
 }
 
 variable "db_name" {

--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}


### PR DESCRIPTION
Upgraded RDS module to TF 0.12. It was required to remove the extra brackets for all data resources required to pull the internal-subnets (it is an output which already comes as a list) as TF upgrade specify:

```
      # TF-UPGRADE-TODO: In Terraform v0.10 and earlier, it was sometimes necessary to
      # force an interpolation expression to be interpreted as a list by wrapping it
      # in an extra set of list brackets. That form was supported for compatibility in
      # v0.11, but is no longer supported in Terraform v0.12.
      #
      # If the expression in the following list itself returns a list, remove the
      # brackets to avoid interpretation as a list of lists. If the expression
      # returns a single list item then leave it as-is and remove this TODO comment.
```

It was also required to set _db_iops_ variable to `type = number` in order to get working the conditional set in line 102: `storage_type = var.db_iops == 0 ? "gp2" : "io1"`

Code tested against our AWS account with the following values:

```
    var.cluster_name
      Enter a value: live-1
    
    var.cluster_state_bucket
      Enter a value: cloud-platform-terraform-state
```