### PR TITLE
Make db_parameter as variable to allow creation of different DB family

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -126,10 +126,13 @@ resource "aws_db_parameter_group" "custom_parameters" {
   name   = local.identifier
   family = var.rds_family
 
-  parameter {
-    name         = "rds.force_ssl"
-    value        = var.force_ssl ? 1 : 0
-    apply_method = var.apply_method
+  dynamic "parameter" {
+    for_each = var.db_parameter
+    content {
+      apply_method = lookup(parameter.value, "apply_method", null)
+      name         = parameter.value.name
+      value        = parameter.value.value
+    }
   }
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -90,3 +90,20 @@ variable "ca_cert_identifier" {
   description = "Specifies the identifier of the CA certificate for the DB instance"
   default     = "rds-ca-2019"
 }
+
+variable "db_parameter" {
+  type = list(object({
+    apply_method = string
+    name         = string
+    value        = string
+  }))
+  default = [
+    {
+      name         = "rds.force_ssl"
+      value        = "true"
+      apply_method = "immediate"
+    }
+  ]
+  description = "A list of DB parameters to apply. Note that parameters may differ from a DB family to another"
+}
+


### PR DESCRIPTION
Related to: https://github.com/ministryofjustice/cloud-platform/issues/1560
What: To allow creating different DB family other than postgres. Currently the parameters for aws_db_parameter_group are hard coded to support postgres(eg. force_ssl). This creates a issue if user wants to create different DB family where the parameters are different. 

This PR will allow creating DB family where parameters can be passed as variable. The default values are
`  default = [
    {
      name         = "rds.force_ssl"
      value        = "true"
      apply_method = "immediate"
    }`  

To apply this PR as a release,
1. Users who used `force_ssl = true` has to remove the line and hence the default values are being picked up
2. Users who use `force_ssl = "false"` has to replace the line with 
`  db_parameter = [
    {
      name         = "rds.force_ssl"
      value        = "false"
      apply_method = "immediate"
    }
]`
3. Any new requests for RDS module who do-not want to use the default values should provide the db_parameter = [] required.
