### PR TITLE
Add custom RDS naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ When upgrading the major version of an engine, `allow_major_version_upgrade` mus
 
 Some engines can't apply some parameters without a reboot(ex postgres9.x cant apply force_ssl immediate), and you will need to specify "pending-reboot" here.
 
+By default, a random name will be generated for the RDS. The `rds_name` parameters allows to set this identifier. 
+Warning: Changing this identifier will recreated the RDS.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ See [this example](example/rds.tf)
 | db_backup_retention_period | The days to retain backups. Must be 1 or greater to be a source for a Read Replica | string | `7` | yes
 | db_iops | The amount of provisioned IOPS. Setting this implies a storage_type of io1 | string | `0` | ** Required if 'db_storage_type' is set to io1 ** |
 | db_name | The name of the database to be created on the instance (if empty, it will be the generated random identifier) | string |  | no |
+| rds_name | Name of the RDS  | string | if not present a name will be generated | no  |
 | force_ssl | Enforce SSL connections | boolean | `true` | no |
 | performance_insights_enabled | Enable performance insights in RDS | boolean | `false` | no |
 | snapshot_identifier | Specifies whether or not to create this database from a snapshot. This correlates to the snapshot ID you'd find in the RDS console. | string | | no |

--- a/example/README.md
+++ b/example/README.md
@@ -11,5 +11,6 @@ The output will be in a kubernetes `Secret`, which includes the values `rds_inst
 In your namespace's path in the [cloud-platform-environments](https://github.com/ministryofjustice/cloud-platform-environments/) repository, create a directory called `resources` (if you have not created one already) and refer to the contents of [main.tf](main.tf) to define the module properties. Make sure to change placeholder values to what is appropriate and refer to the top-level README file in this repository for extra variables that you can use to further customise your resource.
 
 **Warning** due to an API (specific to Postgres instances) limitation, the variable `db_name` must consist only of letters and underscores. Also, if not defined, a random string will be generated.
+For a similar reason, changing the `rds_name` will result in the RDS being recreated
 
 Commit your changes to a branch and raise a pull request. Once approved, you can merge and the changes will be applied. Shortly after, you should be able to access the `Secret` on kubernetes and acccess the resources. You might want to refer to the [documentation on Secrets](https://kubernetes.io/docs/concepts/configuration/secret/).

--- a/example/rds.tf
+++ b/example/rds.tf
@@ -21,13 +21,17 @@ variable "cluster_state_bucket" {
 # Make sure you restart your pods which use this RDS secret to avoid any down time.
 
 module "example_team_rds" {
-  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.3"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.4"
   cluster_name         = var.cluster_name
   cluster_state_bucket = var.cluster_state_bucket
   team_name            = "example-repo"
   business-unit        = "example-bu"
   application          = "exampleapp"
-  is-production        = "false"
+  is-production        = "false" 
+
+  # If the rds_name is not specified a random name will be generated ( cp-* )
+  # Changing the RDS name requires the RDS to be re-created (destroy + create)
+  # rds_name             = "my-rds-name" 
 
   # enable performance insights
   performance_insights_enabled = true  

--- a/main.tf
+++ b/main.tf
@@ -88,7 +88,7 @@ resource "aws_security_group" "rds-sg" {
 }
 
 resource "aws_db_instance" "rds" {
-  identifier                   = local.identifier
+  identifier                   = var.rds_name != "" ? var.rds_name : local.identifier
   final_snapshot_identifier    = "${local.identifier}-finalsnapshot"
   allocated_storage            = var.db_allocated_storage
   apply_immediately            = true

--- a/variables.tf
+++ b/variables.tf
@@ -25,6 +25,11 @@ variable "infrastructure-support" {
   description = "The team responsible for managing the infrastructure. Should be of the form <team-name> (<team-email>)"
 }
 
+
+variable "rds_name"{
+  description = "Optional name of the RDS cluster"
+  default = ""
+}
 variable "snapshot_identifier" {
   description = "Specifies whether or not to create this database from a snapshot. This correlates to the snapshot ID you'd find in the RDS console."
   default     = ""

--- a/variables.tf
+++ b/variables.tf
@@ -25,11 +25,11 @@ variable "infrastructure-support" {
   description = "The team responsible for managing the infrastructure. Should be of the form <team-name> (<team-email>)"
 }
 
-
 variable "rds_name"{
-  description = "Optional name of the RDS cluster"
+  description = "Optional name of the RDS cluster. Changing the name will re-create the RDS"
   default = ""
 }
+
 variable "snapshot_identifier" {
   description = "Specifies whether or not to create this database from a snapshot. This correlates to the snapshot ID you'd find in the RDS console."
   default     = ""


### PR DESCRIPTION
Introduce optional `rds_name` variable.
If not provided, the module will generate a random identifier for the RDS.