### PR TITLE
Make db_parameter as variable to allow creation of different DB family

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -127,11 +127,15 @@ resource "aws_db_parameter_group" "custom_parameters" {
   name   = local.identifier
   family = var.rds_family
 
-  parameter {
-    name         = "rds.force_ssl"
-    value        = var.force_ssl ? 1 : 0
-    apply_method = var.apply_method
+  dynamic "parameter" {
+    for_each = var.db_parameter
+    content {
+      apply_method = lookup(parameter.value, "apply_method", null)
+      name         = parameter.value.name
+      value        = parameter.value.value
+    }
   }
+  
 }
 
 resource "aws_iam_user" "user" {

--- a/variables.tf
+++ b/variables.tf
@@ -97,3 +97,18 @@ variable "performance_insights_enabled" {
   default     = false
 }
 
+variable "db_parameter" {
+  type = list(object({
+    apply_method = string
+    name         = string
+    value        = string
+  }))
+  default = [
+    {
+      name         = "rds.force_ssl"
+      value        = "true"
+      apply_method = "immediate"
+    }
+  ]
+  description = "A list of DB parameters to apply. Note that parameters may differ from a DB family to another"
+}


### PR DESCRIPTION
Re-applying the PR https://github.com/ministryofjustice/cloud-platform-terraform-rds-instance/pull/46 to main branch.

This allows the custom_parameters to accept variables supporting all DB engines.