### PR TITLE
Setting true to 1 as terraform interprets 'true' as 0 when passed as s…

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -101,7 +101,7 @@ variable "db_parameter" {
   default = [
     {
       name         = "rds.force_ssl"
-      value        = "true"
+      value        = "1"
       apply_method = "immediate"
     }
   ]


### PR DESCRIPTION
…tring

- Because of this, terraform plan always shows there is a change and change true to 0. But it actually has to be set to 1 to enable force_ssl for RDS.