### PR TITLE
Adding replicate_source_db variable to support read_replica 

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,17 +32,18 @@ See [this example](example/rds.tf)
 | db_engine | Database engine used | string | `postgres` | no |
 | db_engine_version | The engine version to use | string | `10.4` | no |
 | db_instance_class | The instance type of the RDS instance | string | `db.t2.small` | no |
-| db_backup_retention_period | The days to retain backups. Must be 1 or greater to be a source for a Read Replica | string | `7` | yes
+| db_backup_retention_period | The days to retain backups. Must be 1 or greater to be a source for a Read Replica. Must be 0 for read replica db | string | `7` | yes
 | db_iops | The amount of provisioned IOPS. Setting this implies a storage_type of io1 | string | `0` | ** Required if 'db_storage_type' is set to io1 ** |
 | db_name | The name of the database to be created on the instance (if empty, it will be the generated random identifier) | string |  | no |
 | rds_name | Name of the RDS  | string | if not present a name will be generated | no  |
-| force_ssl | Enforce SSL connections | boolean | `true` | no |
 | performance_insights_enabled | Enable performance insights in RDS | boolean | `false` | no |
 | snapshot_identifier | Specifies whether or not to create this database from a snapshot. This correlates to the snapshot ID you'd find in the RDS console. | string | | no |
 | providers | provider (and region) creating the resources |  arrays of string | default provider | no |
 | rds_family | rds configuration version | string | `postgres10` | no  |
-| apply_method | Indicates when to apply parameter updates | string | `immediate` | no  |
 | ca_cert_identifier | Specifies the identifier of the CA certificate for the DB instance | string | `rds-ca-2019` | no  |
+| db_parameter | Parameter block with name, value and apply_method | list | [ { name = "rds.force_ssl", value = "1", apply_method = "immediate" }]  | yes  |
+| replicate_source_db | Specifies that this resource is a Replicate database, and to use this value as the source database. This correlates to the identifier of another Amazon RDS Database to replicate. | string | <source DB db_identifier> | no  
+| skip_final_snapshot | If false(default) all DB are taken a final snapshot unless the db instance is created from snapshot itself or a read replica." | string | `false` | no  
 
 
 ### Tags

--- a/example/rds.tf
+++ b/example/rds.tf
@@ -21,7 +21,7 @@ variable "cluster_state_bucket" {
 # Make sure you restart your pods which use this RDS secret to avoid any down time.
 
 module "example_team_rds" {
-  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.4"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.5"
   cluster_name         = var.cluster_name
   cluster_state_bucket = var.cluster_state_bucket
   team_name            = "example-repo"
@@ -55,6 +55,17 @@ module "example_team_rds" {
   #   }
   # ]
 
+  # Set below values if you want to create read replica db instance
+
+  # Set the database_name of the source db
+  # db_name = module.example_team_rds.database_name
+
+  # If specifies, this resource is a Replicate database. Set the db_identifier of the source db 
+  # replicate_source_db         = module.example_team_rds.db_identifier
+
+  # Set to true for replica database. No backups or snapshots are created for read replica
+  # skip_final_snapshot         = "true"
+  # db_backup_retention_period  = 0
 
   # use "allow_major_version_upgrade" when upgrading the major version of an engine
   allow_major_version_upgrade = "true"

--- a/output.tf
+++ b/output.tf
@@ -30,10 +30,16 @@ output "database_password" {
 
 output "access_key_id" {
   description = "Access key id for RDS IAM user"
-  value       = aws_iam_access_key.user.id
+  value       = join("", aws_iam_access_key.user.*.id)
+
 }
 
 output "secret_access_key" {
   description = "Secret key for RDS IAM user"
-  value       = aws_iam_access_key.user.secret
+  value       = join("", aws_iam_access_key.user.*.secret)
+}
+
+output "db_identifier" {
+  description = "The RDS DB Indentifer"
+  value       = aws_db_instance.rds.identifier
 }

--- a/variables.tf
+++ b/variables.tf
@@ -47,7 +47,7 @@ variable "db_engine" {
 
 variable "db_engine_version" {
   description = "The engine version to use e.g. 10"
-  default     = "10"
+  default     = "10.11"
 }
 
 variable "db_instance_class" {
@@ -116,6 +116,6 @@ variable "replicate_source_db" {
 
 variable "skip_final_snapshot" {
   type        = string
-  description = "If false(default) all DB are taken a final snapshot unless the db instance is created from snapshot itself or a read replica."
+  description = "if false(default), a DB snapshot is created before the DB instance is deleted, using the value from final_snapshot_identifier. If true no DBSnapshot is created"
   default     = "false"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -25,9 +25,9 @@ variable "infrastructure-support" {
   description = "The team responsible for managing the infrastructure. Should be of the form <team-name> (<team-email>)"
 }
 
-variable "rds_name"{
+variable "rds_name" {
   description = "Optional name of the RDS cluster. Changing the name will re-create the RDS"
-  default = ""
+  default     = ""
 }
 
 variable "snapshot_identifier" {
@@ -76,19 +76,9 @@ variable "allow_major_version_upgrade" {
   default     = "false"
 }
 
-variable "force_ssl" {
-  description = "Enforce SSL connections, set to true to enable"
-  default     = "true"
-}
-
 variable "rds_family" {
   description = "Maps the postgres version with the rds family, a family often covers several versions"
   default     = "postgres10"
-}
-
-variable "apply_method" {
-  description = "Indicates when to apply parameter updates, some engines can't apply some parameters without a reboot, so set to pending-reboot"
-  default     = "immediate"
 }
 
 variable "ca_cert_identifier" {
@@ -111,9 +101,21 @@ variable "db_parameter" {
   default = [
     {
       name         = "rds.force_ssl"
-      value        = "true"
+      value        = "1"
       apply_method = "immediate"
     }
   ]
   description = "A list of DB parameters to apply. Note that parameters may differ from a DB family to another"
+}
+
+variable "replicate_source_db" {
+  description = "Specifies that this resource is a Replicate database, and to use this value as the source database. This correlates to the identifier of another Amazon RDS Database to replicate."
+  type        = string
+  default     = ""
+}
+
+variable "skip_final_snapshot" {
+  type        = string
+  description = "If false(default) all DB are taken a final snapshot unless the db instance is created from snapshot itself or a read replica."
+  default     = "false"
 }


### PR DESCRIPTION
Related to: https://github.com/ministryofjustice/cloud-platform/issues/1859

Variable db_identifier and skip_final_snapshot can now be changed when using this module

Creating read replica db instance doesnot require several variables to be passed when creating RDS instance such as aws_kms_key, db_subnet_group, DB username and DB password.

For read replica, final_snapshot_identifier has to be null as there are no snapshots created for read replica.
Variable skip_final_snapshot has to be set to true for read replica. For normal RDS instance, it is set to false(default)

ca_cert_identifier is not set explicitly as this causes read replica to reboot and not-ready state. Related to: https://github.com/terraform-providers/terraform-provider-aws/issues/11905
All the users of this module have set to default rds-ca-2019. So no users use old certificate.
 
