### PR TITLE
Fix configmap name

### DIFF
--- a/template/rds.tmpl
+++ b/template/rds.tmpl
@@ -54,7 +54,7 @@ resource "kubernetes_secret" "rds" {
 
 resource "kubernetes_config_map" "rds" {
   metadata {
-    name      = "rds-instance_output"
+    name      = "rds-instance-output"
     namespace = var.namespace
   }
 


### PR DESCRIPTION
Underscores are not allowed here, so 
`rds-instance_output` causes terraform plan to 
fail.