### PR TITLE
Add namespace tag

### DIFF
--- a/example/rds.tf
+++ b/example/rds.tf
@@ -28,10 +28,11 @@ module "example_team_rds" {
   business-unit        = "example-bu"
   application          = "exampleapp"
   is-production        = "false"
+  namespace            = var.namespace
 
   # If the rds_name is not specified a random name will be generated ( cp-* )
   # Changing the RDS name requires the RDS to be re-created (destroy + create)
-  # rds_name             = "my-rds-name" 
+  # rds_name             = "my-rds-name"
 
   # enable performance insights
   performance_insights_enabled = true
@@ -45,7 +46,7 @@ module "example_team_rds" {
   # Pick the one that defines the postgres version the best
   rds_family = "postgres10"
 
-  # Some engines can't apply some parameters without a reboot(ex postgres9.x cant apply force_ssl immediate). 
+  # Some engines can't apply some parameters without a reboot(ex postgres9.x cant apply force_ssl immediate).
   # You will need to specify "pending-reboot" here, as default is set to "immediate".
   # db_parameter = [
   #   {
@@ -64,8 +65,8 @@ module "example_team_rds" {
   }
 }
 
-# To create a read replica, use the below code and update the values to specify the RDS instance 
-# from which you are replicating. In this example, we're assuming that example_team_rds is the 
+# To create a read replica, use the below code and update the values to specify the RDS instance
+# from which you are replicating. In this example, we're assuming that example_team_rds is the
 # source RDS instance,and example-team-read-replica is the replica we are creating.
 
 module "example_team_read_replica" {
@@ -80,7 +81,7 @@ module "example_team_read_replica" {
   infrastructure-support = var.infrastructure-support
   team_name              = var.team_name
 
-  # If any other inputs of the RDS is passed in the source db which are different from defaults, 
+  # If any other inputs of the RDS is passed in the source db which are different from defaults,
   # add them to the replica
 
 
@@ -89,7 +90,7 @@ module "example_team_read_replica" {
   # Set the database_name of the source db
   db_name = module.example_team_rds.database_name
 
-  # Set the db_identifier of the source db 
+  # Set the db_identifier of the source db
   replicate_source_db         = module.example_team_rds.db_identifier
 
   # Set to true. No backups or snapshots are created for read replica
@@ -101,7 +102,7 @@ module "example_team_read_replica" {
     aws = aws.london
   }
 
-  # If db_parameter is specified in source rds instance, use the same values. 
+  # If db_parameter is specified in source rds instance, use the same values.
   # If not specified you dont need to add any. It will use the default values.
 
   # db_parameter = [
@@ -144,7 +145,7 @@ resource "kubernetes_secret" "example_team_read_replica" {
   }
 
   # The database_username, database_password, database_name values are same as the source RDS instance.
-  
+
   data = {
     rds_instance_endpoint = module.example_team_read_replica.rds_instance_endpoint
     rds_instance_address  = module.example_team_read_replica.rds_instance_address

--- a/main.tf
+++ b/main.tf
@@ -32,7 +32,7 @@ resource "random_password" "password" {
 }
 
 resource "aws_kms_key" "kms" {
-  count = var.replicate_source_db != "" ? 0 : 1
+  count       = var.replicate_source_db != "" ? 0 : 1
   description = local.identifier
 
   tags = {
@@ -42,17 +42,18 @@ resource "aws_kms_key" "kms" {
     environment-name       = var.environment-name
     owner                  = var.team_name
     infrastructure-support = var.infrastructure-support
+    namespace              = var.namespace
   }
 }
 
 resource "aws_kms_alias" "alias" {
-  count = var.replicate_source_db != "" ? 0 : 1
+  count         = var.replicate_source_db != "" ? 0 : 1
   name          = "alias/${local.identifier}"
-  target_key_id = aws_kms_key.kms[0].key_id 
+  target_key_id = aws_kms_key.kms[0].key_id
 }
 
 resource "aws_db_subnet_group" "db_subnet" {
-  count = var.replicate_source_db != "" ? 0 : 1
+  count      = var.replicate_source_db != "" ? 0 : 1
   name       = local.identifier
   subnet_ids = data.terraform_remote_state.cluster.outputs.internal_subnets_ids
 
@@ -63,6 +64,7 @@ resource "aws_db_subnet_group" "db_subnet" {
     environment-name       = var.environment-name
     owner                  = var.team_name
     infrastructure-support = var.infrastructure-support
+    namespace              = var.namespace
   }
 }
 
@@ -125,6 +127,7 @@ resource "aws_db_instance" "rds" {
     environment-name       = var.environment-name
     owner                  = var.team_name
     infrastructure-support = var.infrastructure-support
+    namespace              = var.namespace
   }
 }
 
@@ -145,13 +148,13 @@ resource "aws_db_parameter_group" "custom_parameters" {
 
 resource "aws_iam_user" "user" {
   count = var.replicate_source_db != "" ? 0 : 1
-  name = "rds-snapshots-user-${random_id.id.hex}"
-  path = "/system/rds-snapshots-user/"
+  name  = "rds-snapshots-user-${random_id.id.hex}"
+  path  = "/system/rds-snapshots-user/"
 }
 
 resource "aws_iam_access_key" "user" {
   count = var.replicate_source_db != "" ? 0 : 1
-  user = aws_iam_user.user[0].name
+  user  = aws_iam_user.user[0].name
 }
 
 data "aws_iam_policy_document" "policy" {
@@ -175,7 +178,7 @@ data "aws_iam_policy_document" "policy" {
 }
 
 resource "aws_iam_user_policy" "policy" {
-  count = var.replicate_source_db != "" ? 0 : 1
+  count  = var.replicate_source_db != "" ? 0 : 1
   name   = "rds-snapshots-read-write"
   policy = data.aws_iam_policy_document.policy.json
   user   = aws_iam_user.user[0].name

--- a/template/rds.tmpl
+++ b/template/rds.tmpl
@@ -7,6 +7,7 @@ module "rds" {
   business-unit        = var.business_unit
   application          = var.application
   is-production        = var.is_production
+  namespace            = var.namespace
 
   # enable performance insights
   performance_insights_enabled = true

--- a/variables.tf
+++ b/variables.tf
@@ -16,9 +16,13 @@ variable "is-production" {
   default = "false"
 }
 
+variable "namespace" {
+  default = ""
+}
+
 variable "business-unit" {
   description = "Area of the MOJ responsible for the service"
-  default     = "mojdigital"
+  default     = ""
 }
 
 variable "infrastructure-support" {


### PR DESCRIPTION
This is to support the AWS cost reporter, so that we can breakdown AWS resource costs per namespace.

Add a "namespace" tag with a value of `var.namespace` to all AWS resources created via this module.

Also, remove the default "mojdigital" value for the `business-unit` tag - that's not a valid value, and we should be requiring users to supply the correct value anyway.