### PR TITLE
Added resource ID in order to use/query Performance Insights metrics

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -176,7 +176,7 @@ data "aws_iam_policy_document" "policy" {
       "arn:aws:rds:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:snapshot:*",
     ]
   }
-  
+
   statement {
     actions = [
       "pi:*",

--- a/output.tf
+++ b/output.tf
@@ -43,3 +43,8 @@ output "db_identifier" {
   description = "The RDS DB Indentifer"
   value       = aws_db_instance.rds.identifier
 }
+
+output "resource_id" {
+  description = "RDS Resource ID - used for performance insights (metrics)"
+  value       = aws_db_instance.rds.resource_id
+}


### PR DESCRIPTION
When we use performance Insights we need to reference the database by its resource ID instead of identifier. As it shows 

```
$ aws pi get-resource-metrics --service-type RDS --identifier cloud-platform-bfcf59724ea63960 --start-time `expr \`date +%s\` - 600 ` --end-time `expr \`date +%s\` - 300 ` --metric-queries '[{"Metric": "db.Transactions.xact_commit.avg" }]'
```

Unfortunately, it doesn't work if you use the RDS identifier, only works with the resource ID. So users need to be able to get resource ID as an output of the terraform module.