### PR TITLE
Deleted action `AmazonRDSReadOnlyAccess`

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -166,7 +166,6 @@ data "aws_iam_policy_document" "policy" {
       "rds:DescribeDBSnapshotAttributes",
       "rds:ModifyDBSnapshot",
       "rds:CreateDBSnapshot",
-      "rds:AmazonRDSReadOnlyAccess",
       "rds:RestoreDBInstanceFromDBSnapshot",
       "rds:ModifyDBSnapshotAttribute",
     ]


### PR DESCRIPTION
There is not such action like that: it is a policy