### PR TITLE
Add "modify instance" permissions

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -176,7 +176,7 @@ data "aws_iam_policy_document" "policy" {
       aws_db_instance.rds.arn,
       "arn:aws:rds:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:snapshot:*",
       aws_db_parameter_group.custom_parameters.arn,
-      "arn:aws:rds:${data.aws_region.current.name}:pg:default.*"
+      "arn:aws:rds:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:pg:default.*"
     ]
   }
 

--- a/main.tf
+++ b/main.tf
@@ -168,11 +168,14 @@ data "aws_iam_policy_document" "policy" {
       "rds:CreateDBSnapshot",
       "rds:RestoreDBInstanceFromDBSnapshot",
       "rds:ModifyDBSnapshotAttribute",
+      "rds:ModifyDBInstance",
     ]
 
     resources = [
       aws_db_instance.rds.arn,
       "arn:aws:rds:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:snapshot:*",
+      aws_db_parameter_group.custom_parameters.arn,
+      "arn:aws:rds:${data.aws_region.current.name}:pg:default.*"
     ]
   }
 

--- a/main.tf
+++ b/main.tf
@@ -161,6 +161,7 @@ data "aws_iam_policy_document" "policy" {
   statement {
     actions = [
       "rds:DescribeDBSnapshots",
+      "rds:DescribeDBInstances",
       "rds:CopyDBSnapshot",
       "rds:DeleteDBSnapshot",
       "rds:DescribeDBSnapshotAttributes",


### PR DESCRIPTION
This change gives the IAM user created with the RDS instance additional
permissions, to enable users to upgrade their own RDS instances with
minimal involvement from the CP team.

The upgrade process is:

* Change RDS instance to use the defeault parameter group for it's
  db_engine
* Tell the pipeline to upgrade the RDS instance via a normal env. repo.
  PR

`rds:ModifyDBInstance` permission is required to change the instance's
DBParameterGroup.

Permissions on
`arn:aws:rds:${data.aws_region.current.name}:pg:default.*` are required
so that we can add the RDS instance to the parameter group's list of RDS
instance members.

Permissions on `aws_db_parameter_group.custom_parameters.arn` are
required to allow the IAM user to switch the RDS instance **back** to
the original parameter group (they shouldn't need to do this, during an
upgrade, but it allows them to roll back the first step, just in case).
