### PR TITLE
Add storage autoscaling

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ See [this example](example/rds.tf)
 | cluster_name | The name of the cluster (eg.: cloud-platform-live-0) | string |  | yes |
 | cluster_state_bucket | The name of the S3 bucket holding the terraform state for the cluster | string | | yes |
 | db_allocated_storage | The allocated storage in gibibytes | string | `10` | no |
+| db_max_allocated_storage | Total storage in gibibytes up to which this RDS will autoscale | string | `10000` | no |
 | db_engine | Database engine used | string | `postgres` | no |
 | db_engine_version | The engine version to use | string | `10.4` | no |
 | db_instance_class | The instance type of the RDS instance | string | `db.t2.small` | no |

--- a/example/rds.tf
+++ b/example/rds.tf
@@ -21,7 +21,7 @@ variable "cluster_state_bucket" {
 # Make sure you restart your pods which use this RDS secret to avoid any down time.
 
 module "example_team_rds" {
-  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.11"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.12"
   cluster_name         = var.cluster_name
   cluster_state_bucket = var.cluster_state_bucket
   team_name            = "example-repo"

--- a/main.tf
+++ b/main.tf
@@ -96,6 +96,7 @@ resource "aws_db_instance" "rds" {
   identifier                   = var.rds_name != "" ? var.rds_name : local.identifier
   final_snapshot_identifier    = var.replicate_source_db != "" ? null : "${local.identifier}-finalsnapshot"
   allocated_storage            = var.db_allocated_storage
+  max_allocated_storage        = var.db_max_allocated_storage
   apply_immediately            = true
   engine                       = var.db_engine
   engine_version               = var.db_engine_version

--- a/template/rds.tmpl
+++ b/template/rds.tmpl
@@ -1,6 +1,6 @@
 
 module "rds" {
-  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.9"
+  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.12"
   cluster_name         = var.cluster_name
   cluster_state_bucket = var.cluster_state_bucket
   team_name            = var.team_name

--- a/variables.tf
+++ b/variables.tf
@@ -44,6 +44,11 @@ variable "db_allocated_storage" {
   default     = "10"
 }
 
+variable "db_max_allocated_storage" {
+  description = "Maximum storage limit for storage autoscaling"
+  default     = "10000"
+}
+
 variable "db_engine" {
   description = "Database engine used e.g. postgres, mqsql"
   default     = "postgres"


### PR DESCRIPTION
Add a db_max_allocated_storage terraform variable which defaults to 10TB, and gets passed through to the AWS instance definition as max_allocated_storage.

Once this PR is merged, create a 5.12 release.

This is the maximum up to which the RDS instance will be allowed to scale its storage amount. Setting this value has the effect of enabling storage autoscaling on the RDS instance.

I've carried out 2 tests on this module:

1. Create an RDS with this module version - RDS instance is created with storage autoscaling enabled (as shown in the configuration tab of the AWS console page for the RDS instance)

2. Create an RDS instance with the current version (5.10) of the module, insert some data and then change the module version to this version and terraform apply while accessing the database via psql and a port-forward pod.

Results:

* The existing RDS instance is modified in place
* The data is unaffected
* The connection to the database continued to work throughout the terraform apply

So, I think it's safe to update all our existing RDS instances to use this version of the module (doing non-prod and prod in 2 separate PRs).

- Add `db_max_allocated_storage` variable
- Update example & template to use version 5.12
- Add `db_max_allocated_storage` to the README

fixes ministryofjustice/cloud-platform#1621
