### PR TITLE
Correct var. to `infrastructure_support`

### DIFF
--- a/template/rds.tmpl
+++ b/template/rds.tmpl
@@ -15,7 +15,7 @@ module "rds" {
   # change the postgres version as you see fit.
   db_engine_version      = "10"
   environment-name       = var.environment
-  infrastructure-support = var.infrastructure-support
+  infrastructure-support = var.infrastructure_support
 
   # rds_family should be one of: postgres9.4, postgres9.5, postgres9.6, postgres10, postgres11
   # Pick the one that defines the postgres version the best


### PR DESCRIPTION
When we create an environment using the CLI tool, the variable
`infrastructure_support` is defined in `variables.tf`

This change corrects the template to use the correct variable name.
Prior to this, the following sequence of commands will not work:

```
cloud-platform environment create
cloud-platform environment rds create
```

...because the pipeline will throw this error:

```
Error: Reference to undeclared input variable

  on rds.tf line 18, in module "rds":
  18:   infrastructure-support = var.infrastructure-support

An input variable with the name "infrastructure-support" has not been
declared. Did you mean "infrastructure_support"?
```
