### PR TITLE
Using AWS data resources instead of remote state

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,6 @@ See [this example](example/rds.tf)
 | allow_major_version_upgrade | Indicates that major version upgrades are allowed |  string | false | no |
 | allow_minor_version_upgrade | Indicates that minor upgrades (eg 12.x for Postgres) are allowed |  bool | true | no |
 | cluster_name | The name of the cluster (eg.: cloud-platform-live-0) | string |  | yes |
-| cluster_state_bucket | The name of the S3 bucket holding the terraform state for the cluster | string | | yes |
 | db_allocated_storage | The allocated storage in gibibytes | string | `10` | no |
 | db_max_allocated_storage | Total storage in gibibytes up to which this RDS will autoscale | string | `10000` | no |
 | db_engine | Database engine used | string | `postgres` | no |

--- a/example/rds.tf
+++ b/example/rds.tf
@@ -4,11 +4,7 @@
  *
  */
 
-variable "cluster_name" {
-}
-
-variable "cluster_state_bucket" {
-}
+variable "cluster_name" {}
 
 /*
  * Make sure that you use the latest version of the module by changing the
@@ -21,14 +17,13 @@ variable "cluster_state_bucket" {
 # Make sure you restart your pods which use this RDS secret to avoid any down time.
 
 module "example_team_rds" {
-  source               = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.13.1"
-  cluster_name         = var.cluster_name
-  cluster_state_bucket = var.cluster_state_bucket
-  team_name            = "example-repo"
-  business-unit        = "example-bu"
-  application          = "exampleapp"
-  is-production        = "false"
-  namespace            = var.namespace
+  source        = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.13.1"
+  cluster_name  = var.cluster_name
+  team_name     = "example-repo"
+  business-unit = "example-bu"
+  application   = "exampleapp"
+  is-production = "false"
+  namespace     = var.namespace
 
   # If the rds_name is not specified a random name will be generated ( cp-* )
   # Changing the RDS name requires the RDS to be re-created (destroy + create)
@@ -73,8 +68,6 @@ module "example_team_read_replica" {
   source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.8"
 
   cluster_name         = var.cluster_name
-  cluster_state_bucket = var.cluster_state_bucket
-
   application            = var.application
   environment-name       = var.environment-name
   is-production          = var.is-production
@@ -91,11 +84,11 @@ module "example_team_read_replica" {
   db_name = module.example_team_rds.database_name
 
   # Set the db_identifier of the source db
-  replicate_source_db         = module.example_team_rds.db_identifier
+  replicate_source_db = module.example_team_rds.db_identifier
 
   # Set to true. No backups or snapshots are created for read replica
-  skip_final_snapshot         = "true"
-  db_backup_retention_period  = 0
+  skip_final_snapshot        = "true"
+  db_backup_retention_period = 0
 
   providers = {
     # Can be either "aws.london" or "aws.ireland"

--- a/main.tf
+++ b/main.tf
@@ -1,15 +1,24 @@
 data "aws_caller_identity" "current" {}
-
 data "aws_region" "current" {}
 
-data "terraform_remote_state" "cluster" {
-  backend = "s3"
-
-  config = {
-    bucket = var.cluster_state_bucket
-    region = "eu-west-1"
-    key    = "cloud-platform/${var.cluster_name}/terraform.tfstate"
+data "aws_vpc" "selected" {
+  filter {
+    name   = "tag:Name"
+    values = [var.cluster_name]
   }
+}
+
+data "aws_subnet_ids" "private" {
+  vpc_id = data.aws_vpc.selected.id
+
+  tags = {
+    SubnetType = "Private"
+  }
+}
+
+data "aws_subnet" "private" {
+  for_each = data.aws_subnet_ids.private.ids
+  id       = each.value
 }
 
 resource "random_id" "id" {
@@ -55,7 +64,7 @@ resource "aws_kms_alias" "alias" {
 resource "aws_db_subnet_group" "db_subnet" {
   count      = var.replicate_source_db != "" ? 0 : 1
   name       = local.identifier
-  subnet_ids = data.terraform_remote_state.cluster.outputs.internal_subnets_ids
+  subnet_ids = data.aws_subnet_ids.private
 
   tags = {
     business-unit          = var.business-unit
@@ -71,7 +80,7 @@ resource "aws_db_subnet_group" "db_subnet" {
 resource "aws_security_group" "rds-sg" {
   name        = local.identifier
   description = "Allow all inbound traffic"
-  vpc_id      = data.terraform_remote_state.cluster.outputs.vpc_id
+  vpc_id      = data.aws_vpc.selected.id
 
   // We cannot use `${aws_db_instance.rds.port}` here because it creates a
   // cyclic dependency. Rather than resorting to `aws_security_group_rule` which
@@ -81,14 +90,14 @@ resource "aws_security_group" "rds-sg" {
     from_port   = 0
     to_port     = 0
     protocol    = "-1"
-    cidr_blocks = data.terraform_remote_state.cluster.outputs.internal_subnets
+    cidr_blocks = [for s in data.aws_subnet.private : s.cidr_block]
   }
 
   egress {
     from_port   = 0
     to_port     = 0
     protocol    = "-1"
-    cidr_blocks = data.terraform_remote_state.cluster.outputs.internal_subnets
+    cidr_blocks = [for s in data.aws_subnet.private : s.cidr_block]
   }
 }
 

--- a/main.tf
+++ b/main.tf
@@ -64,7 +64,7 @@ resource "aws_kms_alias" "alias" {
 resource "aws_db_subnet_group" "db_subnet" {
   count      = var.replicate_source_db != "" ? 0 : 1
   name       = local.identifier
-  subnet_ids = data.aws_subnet_ids.private
+  subnet_ids = [data.aws_subnet_ids.private]
 
   tags = {
     business-unit          = var.business-unit

--- a/main.tf
+++ b/main.tf
@@ -64,7 +64,7 @@ resource "aws_kms_alias" "alias" {
 resource "aws_db_subnet_group" "db_subnet" {
   count      = var.replicate_source_db != "" ? 0 : 1
   name       = local.identifier
-  subnet_ids = [data.aws_subnet_ids.private]
+  subnet_ids = data.aws_subnet_ids.private.ids
 
   tags = {
     business-unit          = var.business-unit

--- a/variables.tf
+++ b/variables.tf
@@ -2,10 +2,6 @@ variable "cluster_name" {
   description = "The name of the cluster (eg.: cloud-platform-live-0)"
 }
 
-variable "cluster_state_bucket" {
-  description = "The name of the S3 bucket holding the terraform state for the cluster"
-}
-
 variable "team_name" {}
 
 variable "application" {}


### PR DESCRIPTION
In order to remove the interdependence between states (environment and infrastructure), with this change we are using data resources to query AWS API and get the metadata (VPC and subnets IDs)

Tested against cccd-dev's RDS instance:

```
No changes. Infrastructure is up-to-date.

This means that Terraform did not detect any differences between your
configuration and real physical resources that exist. As a result, no
actions need to be performed.
```

as expected, no changes. Metadata is being pulled from AWS instead of terraform state.