### PR TITLE
Provide alternative syntax for 1.18+ kubectl

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,8 +131,21 @@ A Docker image containing the `psql` utility is available from [Bitnami] (you
 cannot use the official postgres image, because it runs as root) and can be
 launched like this:
 
+#### Before kubectl 1.18
+
 ```
 $ kubectl -n [your namespace] run --generator=run-pod/v1 shell --rm -i --tty --image bitnami/postgresql -- bash
+
+If you don't see a command prompt, try pressing enter.
+postgres@shell:/$
+```
+
+#### Since kubectl 1.18
+
+The `run` command can now only create pods, so the `--generator` option was removed:
+
+```
+$ kubectl -n [your namespace] run shell --rm -i --tty --image bitnami/postgresql -- bash
 
 If you don't see a command prompt, try pressing enter.
 postgres@shell:/$


### PR DESCRIPTION
Reflects changes in https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.18.md#kubectl

This means the previous snippet errors out:
```
$ kubectl run --generator=run-pod/v1 shell --rm -i --tty --image bitnami/postgresql -- bash
Error: unknown flag: --generator
See 'kubectl run --help' for usage.
```

I was unsure to replace the section or provide a before/after syntax -- happy to amend if shorter is more preferred