### PR TITLE
Allow a database instance to be associated to an option group

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ No modules.
 | <a name="input_infrastructure-support"></a> [infrastructure-support](#input\_infrastructure-support) | The team responsible for managing the infrastructure. Should be of the form <team-name> (<team-email>) | `any` | n/a | yes |
 | <a name="input_is-production"></a> [is-production](#input\_is-production) | n/a | `string` | `"false"` | no |
 | <a name="input_license_model"></a> [license\_model](#input\_license\_model) | License model information for this DB instance, options are: license-included \| bring-your-own-license \| general-public-license | `string` | `"license-included"` | no |
+| <a name="input_option_group_name"></a> [option_group_name](#input\_option\_group\_name) | The name of an 'aws_db_option_group' to associate to the DB instance | `string` | null | no |
 | <a name="input_namespace"></a> [namespace](#input\_namespace) | n/a | `string` | `""` | no |
 | <a name="input_performance_insights_enabled"></a> [performance\_insights\_enabled](#input\_performance\_insights\_enabled) | Enable performance insights for RDS? | `bool` | `false` | no |
 | <a name="input_rds_family"></a> [rds\_family](#input\_rds\_family) | Maps the postgres version with the rds family, a family often covers several versions | `string` | `"postgres10"` | no |

--- a/main.tf
+++ b/main.tf
@@ -134,6 +134,7 @@ resource "aws_db_instance" "rds" {
   backup_window                = var.backup_window
   license_model                = var.license_model
   character_set_name           = can(regex("sqlserver", var.db_engine)) ? var.character_set_name : null
+  option_group_name            = var.option_group_name
 
   tags = {
     business-unit          = var.business-unit

--- a/variables.tf
+++ b/variables.tf
@@ -157,3 +157,9 @@ variable "character_set_name" {
   description = "DB char set, used only by MS-SQL"
   default     = "SQL_Latin1_General_CP1_CI_AS"
 }
+
+variable "option_group_name" {
+  type        = string
+  description = "(Optional) The name of an 'aws_db_option_group' to associate to the DB instance"
+  default     = null
+}


### PR DESCRIPTION
This allows users to control and configure an option group and associate
this with the database.

One use case for this is enabling native backup and restore in RDS SQL
Server (ref: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Appendix.SQLServer.Options.BackupRestore.html)
- this can only be done via an option group...

(and we - the ppud-replacement team - need to do just that)