### PR TITLE
Allow maintenance window to be configured

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ No modules.
 | <a name="input_allow_minor_version_upgrade"></a> [allow\_minor\_version\_upgrade](#input\_allow\_minor\_version\_upgrade) | Indicates that minor version upgrades are allowed. | `string` | `"true"` | no |
 | <a name="input_application"></a> [application](#input\_application) | n/a | `any` | n/a | yes |
 | <a name="input_backup_window"></a> [backup\_window](#input\_backup\_window) | The daily time range (in UTC) during which automated backups are created if they are enabled. Example: 09:46-10:16 | `string` | `""` | no |
+| <a name="input_maintenance_window"></a> [maintenance\_window](#input\_maintenance\_window) | The window to perform maintenance in. Syntax: "ddd:hh24:mi-ddd:hh24:mi". For example: "Mon:00:00-Mon:03:00". | `string` | `""` | no |
 | <a name="input_business-unit"></a> [business-unit](#input\_business-unit) | Area of the MOJ responsible for the service | `string` | `""` | no |
 | <a name="input_ca_cert_identifier"></a> [ca\_cert\_identifier](#input\_ca\_cert\_identifier) | Specifies the identifier of the CA certificate for the DB instance | `string` | `"rds-ca-2019"` | no |
 | <a name="input_character_set_name"></a> [character\_set\_name](#input\_character\_set\_name) | DB char set, used only by MS-SQL | `string` | `"Latin1_General_CI_AS"` | no |

--- a/main.tf
+++ b/main.tf
@@ -132,6 +132,7 @@ resource "aws_db_instance" "rds" {
   skip_final_snapshot          = var.skip_final_snapshot
   deletion_protection          = var.deletion_protection
   backup_window                = var.backup_window
+  maintenance_window           = var.maintenance_window
   license_model                = var.license_model
   character_set_name           = can(regex("sqlserver", var.db_engine)) ? var.character_set_name : null
   option_group_name            = var.option_group_name

--- a/variables.tf
+++ b/variables.tf
@@ -140,6 +140,12 @@ variable "backup_window" {
   default     = ""
 }
 
+variable "maintenance_window" {
+  type        = string
+  description = "The window to perform maintenance in. Syntax: \"ddd:hh24:mi-ddd:hh24:mi\". For example: \"Mon:00:00-Mon:03:00\"."
+  default     = ""
+}
+
 variable "deletion_protection" {
   type        = string
   description = "(Optional) If the DB instance should have deletion protection enabled. The database can't be deleted when this value is set to true. The default is false."


### PR DESCRIPTION
We'd like to make our maintenance window more explicit so it matches the time when we have the least number of users of our tool. This change allows the window to be set in much the same way that the `backup_window` attribute can be set.

See [Adjusting the preferred DB instance maintenance window](http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_UpgradeDBInstance.Maintenance.html#AdjustingTheMaintenanceWindow) for more information about RDS maintenance windows.