### PR TITLE
Update the RDS template db_instance_class

### DIFF
--- a/example/rds-mysql.tf
+++ b/example/rds-mysql.tf
@@ -26,6 +26,7 @@ module "rds_mysql" {
   db_engine         = "mysql"
   db_engine_version = "8.0.25"
   rds_family        = "mysql8.0"
+  db_instance_class = "db.t3.small"
 
   # overwrite db_parameters. 
   db_parameter = [

--- a/example/rds-postgresql.tf
+++ b/example/rds-postgresql.tf
@@ -26,6 +26,9 @@ module "rds" {
   # change the postgres version as you see fit.
   db_engine_version = "13"
 
+  # change the instance class as you see fit.
+  db_instance_class = "db.t3.small"
+
   # rds_family should be one of: postgres9.4, postgres9.5, postgres9.6, postgres10, postgres11, postgres12, postgres13
   # Pick the one that defines the postgres version the best
   rds_family = "postgres13"


### PR DESCRIPTION
This is to use "db.t3.small" as t2.small can only be used for Lower than PostgreSQL 13