### PR TITLE
Set the db_parameter default to "immediate"

### DIFF
--- a/example/rds-mssql.tf
+++ b/example/rds-mssql.tf
@@ -27,6 +27,16 @@ module "rds_mssql" {
   allow_minor_version_upgrade = true
   allow_major_version_upgrade = false
 
+  # Some engines can't apply some parameters without a reboot(ex SQL Server cant apply force_ssl immediate).
+  # You will need to specify "pending-reboot" here, as default is set to "immediate".
+  db_parameter = [
+    {
+      name         = "rds.force_ssl"
+      value        = "1"
+      apply_method = "pending-reboot"
+    }
+  ]
+
   providers = {
     # Can be either "aws.london" or "aws.ireland"
     aws = aws.london

--- a/example/rds-mysql.tf
+++ b/example/rds-mysql.tf
@@ -39,6 +39,13 @@ module "rds_mysql" {
       name         = "character_set_server"
       value        = "utf8"
       apply_method = "immediate"
+    },
+  # Some engines can't apply some parameters without a reboot(ex SQL Server cant apply force_ssl immediate).
+  # You will need to specify "pending-reboot" here, as default is set to "immediate".
+    {
+      name         = "rds.force_ssl"
+      value        = "1"
+      apply_method = "pending-reboot"
     }
   ]
 

--- a/variables.tf
+++ b/variables.tf
@@ -116,7 +116,7 @@ variable "db_parameter" {
     {
       name         = "rds.force_ssl"
       value        = "1"
-      apply_method = "pending-reboot"
+      apply_method = "immediate"
     }
   ]
   description = "A list of DB parameters to apply. Note that parameters may differ from a DB family to another"


### PR DESCRIPTION
Set the db_parameter default to "immediate"
    
This is because our default db_engine is Postgres , and Postgres doesn't need reboot:
when you set rds.force_ssl to 1, you don't need to reboot your DB instance.
https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/PostgreSQL.Concepts.General.SSL.html
    
For SQL:
The rds.force_ssl parameter is static, so after you change the value, you must reboot your DB instance for the change to take effect.
https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/SQLServer.Concepts.General.SSL.Using.html