### PR TITLE
Update module version, database versions, and instance classes in examples

### DIFF
--- a/example/rds-mssql.tf
+++ b/example/rds-mssql.tf
@@ -6,7 +6,7 @@
 */
 
 module "rds_mssql" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.16.5"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.16.10"
   cluster_name           = var.cluster_name
   team_name              = var.team_name
   business-unit          = var.business_unit
@@ -20,7 +20,7 @@ module "rds_mssql" {
   performance_insights_enabled = true
 
   db_engine                   = "sqlserver-ex"
-  db_engine_version           = "15.00.4073.23.v1"
+  db_engine_version           = "15.00.4198.2.v1"
   db_instance_class           = "db.t3.medium"
   db_allocated_storage        = 32
   rds_family                  = "sqlserver-ex-15.0"

--- a/example/rds-mysql.tf
+++ b/example/rds-mysql.tf
@@ -6,7 +6,7 @@
 */
 
 module "rds_mysql" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.16.5"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.16.10"
   cluster_name           = var.cluster_name
   team_name              = var.team_name
   business-unit          = var.business_unit
@@ -24,9 +24,9 @@ module "rds_mysql" {
 
   # using mysql
   db_engine         = "mysql"
-  db_engine_version = "8.0.25"
+  db_engine_version = "8.0.28"
   rds_family        = "mysql8.0"
-  db_instance_class = "db.t3.small"
+  db_instance_class = "db.t4g.small"
 
   # overwrite db_parameters. 
   db_parameter = [

--- a/example/rds-postgresql.tf
+++ b/example/rds-postgresql.tf
@@ -6,7 +6,7 @@
  */
 
 module "rds" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.16.7"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.16.10"
   cluster_name           = var.cluster_name
   team_name              = var.team_name
   business-unit          = var.business_unit
@@ -24,14 +24,14 @@ module "rds" {
   performance_insights_enabled = true
 
   # change the postgres version as you see fit.
-  db_engine_version = "13"
+  db_engine_version = "14"
 
   # change the instance class as you see fit.
-  db_instance_class = "db.t3.small"
+  db_instance_class = "db.t4g.small"
 
-  # rds_family should be one of: postgres9.4, postgres9.5, postgres9.6, postgres10, postgres11, postgres12, postgres13
+  # rds_family should be one of: postgres10, postgres11, postgres12, postgres13, postgres14
   # Pick the one that defines the postgres version the best
-  rds_family = "postgres13"
+  rds_family = "postgres14"
 
   # Some engines can't apply some parameters without a reboot(ex postgres9.x cant apply force_ssl immediate).
   # You will need to specify "pending-reboot" here, as default is set to "immediate".
@@ -59,7 +59,7 @@ module "rds" {
 module "read_replica" {
   # default off
   count  = 0
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.16.7"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.16.10"
 
   cluster_name           = var.cluster_name
   application            = var.application


### PR DESCRIPTION
This PR updates the `examples` files to use:

- the latest module version
- updated supported database versions
- t4g instance types where appropriate