### PR TITLE
enable_auto_start_stop

### DIFF
--- a/example/rds-mssql.tf
+++ b/example/rds-mssql.tf
@@ -29,6 +29,10 @@ module "rds_mssql" {
 
   # Some engines can't apply some parameters without a reboot(ex SQL Server cant apply force_ssl immediate).
   # You will need to specify "pending-reboot" here, as default is set to "immediate".
+
+  # Enable auto start and stop of the RDS instances during 10:00 PM - 6:00 AM for cost saving, recommended for non-prod instances
+  # enable_rds_auto_start_stop  = true
+
   db_parameter = [
     {
       name         = "rds.force_ssl"

--- a/example/rds-mysql.tf
+++ b/example/rds-mysql.tf
@@ -42,6 +42,9 @@ module "rds_mysql" {
     }
   ]
 
+  # Enable auto start and stop of the RDS instances during 10:00 PM - 6:00 AM for cost saving, recommended for non-prod instances
+  # enable_rds_auto_start_stop  = true
+
   providers = {
     aws = aws.london
   }

--- a/example/rds-postgresql.tf
+++ b/example/rds-postgresql.tf
@@ -46,6 +46,9 @@ module "rds" {
   # use "allow_major_version_upgrade" when upgrading the major version of an engine
   allow_major_version_upgrade = "false"
 
+  # Enable auto start and stop of the RDS instances during 10:00 PM - 6:00 AM for cost saving, recommended for non-prod instances
+  # enable_rds_auto_start_stop  = true
+
   providers = {
     # Can be either "aws.london" or "aws.ireland"
     aws = aws.london

--- a/main.tf
+++ b/main.tf
@@ -31,8 +31,8 @@ locals {
   db_arn                 = aws_db_instance.rds.arn
   db_pg_arn              = aws_db_parameter_group.custom_parameters.arn
   vpc_security_group_ids = concat([aws_security_group.rds-sg.id], var.vpc_security_group_ids)
-  tag_for_auto_shutdown  = var.enable_auto_start_stop ? {"cloud-platform-auto-shutdown" = "Schedule RDS Stop/Start during non-business hours for cost saving"} : null
-  tags                   = {
+  tag_for_auto_shutdown  = var.enable_rds_auto_start_stop ? { "cloud-platform-rds-auto-shutdown" = "Schedule RDS Stop/Start during non-business hours for cost saving" } : null
+  default_tags = {
     business-unit          = var.business-unit
     application            = var.application
     is-production          = var.is-production
@@ -57,7 +57,7 @@ resource "aws_kms_key" "kms" {
   count       = var.replicate_source_db != "" ? 0 : 1
   description = local.identifier
 
-  tags = local.tags
+  tags = local.default_tags
 }
 
 resource "aws_kms_alias" "alias" {
@@ -71,7 +71,7 @@ resource "aws_db_subnet_group" "db_subnet" {
   name       = local.identifier
   subnet_ids = data.aws_subnet_ids.private.ids
 
-  tags = local.tags
+  tags = local.default_tags
 }
 
 resource "aws_security_group" "rds-sg" {
@@ -140,8 +140,7 @@ resource "aws_db_instance" "rds" {
     delete = "2h"
   }
 
-  tags = merge(
-    local.tags, local.tag_for_auto_shutdown)
+  tags = merge(local.default_tags, local.tag_for_auto_shutdown)
 }
 
 resource "aws_db_parameter_group" "custom_parameters" {

--- a/variables.tf
+++ b/variables.tf
@@ -136,6 +136,12 @@ variable "performance_insights_enabled" {
   default     = false
 }
 
+variable "enable_auto_start_stop" {
+  type        = bool
+  description = "Enable auto start and stop of the RDS instances for cost saving, https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_StopInstance.html"
+  default     = false
+}
+
 variable "db_parameter" {
   type = list(object({
     apply_method = string

--- a/variables.tf
+++ b/variables.tf
@@ -136,9 +136,9 @@ variable "performance_insights_enabled" {
   default     = false
 }
 
-variable "enable_auto_start_stop" {
+variable "enable_rds_auto_start_stop" {
   type        = bool
-  description = "Enable auto start and stop of the RDS instances for cost saving, https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_StopInstance.html"
+  description = "Enable auto start and stop of the RDS instances during 10:00 PM - 6:00 AM for cost saving"
   default     = false
 }
 


### PR DESCRIPTION
Enable auto start and stop of the RDS instances for cost saving

Ref:
https://github.com/ministryofjustice/cloud-platform-terraform-aws-scheduler/pull/1