### PR TITLE
Update module version in examples

### DIFF
--- a/example/rds-mssql.tf
+++ b/example/rds-mssql.tf
@@ -6,7 +6,7 @@
 */
 
 module "rds_mssql" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.16.10"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.16.12"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business-unit          = var.business_unit

--- a/example/rds-mysql.tf
+++ b/example/rds-mysql.tf
@@ -6,7 +6,7 @@
 */
 
 module "rds_mysql" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.16.10"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.16.12"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business-unit          = var.business_unit

--- a/example/rds-postgresql.tf
+++ b/example/rds-postgresql.tf
@@ -6,7 +6,7 @@
  */
 
 module "rds" {
-  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.16.10"
+  source                 = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=5.16.12"
   vpc_name               = var.vpc_name
   team_name              = var.team_name
   business-unit          = var.business_unit


### PR DESCRIPTION
The CLI uses these files to generate the rds module. The latest changes of vpc_name needs 5.16.12 and hence the pipeline fails if the rds module is generated from CLI