### PR TITLE
feat: add permissions for orderable DB instance options

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -180,6 +180,7 @@ data "aws_iam_policy_document" "policy" {
       "rds:DescribeDBLogFiles",
       "rds:DescribeDBSnapshotAttributes",
       "rds:DescribeDBSnapshots",
+      "rds:DescribeOrderableDBInstanceOptions",
       "rds:DownloadDBLogFilePortion",
       "rds:ModifyDBInstance",
       "rds:ModifyDBSnapshot",


### PR DESCRIPTION
This enables users to query supported db engine versions against given instance class

https://github.com/ministryofjustice/cloud-platform-user-guide/pull/1266/commits/eb07468951637b0b68d4b61d7a943a4f4c8d6894
