### PR TITLE
📝  fix broken link to example config in README.md.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ When creating Read Replica, make sure to pass the same inputs in the replica ins
 
 ## Usage
 
-See these examples for [MS SQL Server](example/rds-mssql.tf), [MySQL](example/rds-mysql.tf) and [PostGreSQL](example/rds-postgresql.tf).
+See these examples for [MS SQL Server](example/rds-mssql.tf), [MySQL](example/rds-mysql.tf) and [PostgreSQL](example/rds-postgresql.tf).
 
 <!-- BEGIN_TF_DOCS -->
 ## Requirements

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ When creating Read Replica, make sure to pass the same inputs in the replica ins
 
 ## Usage
 
-See [this example](example/rds.tf)
+See these examples for [MS SQL Server](example/rds-mssql.tf), [MySQL](example/rds-mysql.tf) and [PostGreSQL](example/rds-postgresql.tf).
 
 <!-- BEGIN_TF_DOCS -->
 ## Requirements


### PR DESCRIPTION
It looks like in the past, the single example was expanded to separate examples for MySQL, MSSQL and Postgres but the README.md wasn't updated. This PR remedies that. 

There are no functional changes in this PR.