### PR TITLE
Add a new variable to simplify parameter group resetting on major version upgrades

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ No modules.
 | <a name="input_namespace"></a> [namespace](#input\_namespace) | Namespace name | `string` | `""` | no |
 | <a name="input_option_group_name"></a> [option\_group\_name](#input\_option\_group\_name) | (Optional) The name of an 'aws\_db\_option\_group' to associate to the DB instance | `string` | `null` | no |
 | <a name="input_performance_insights_enabled"></a> [performance\_insights\_enabled](#input\_performance\_insights\_enabled) | Enable performance insights for RDS? | `bool` | `false` | no |
+| <a name="input_prepare_for_major_upgrade"></a> [prepare\_for\_major\_upgrade](#input\_prepare\_for\_major\_upgrade) | Set this to true to change your parameter group to the default version, and to turn on the ability to upgrade major versions | `bool` | `false` | no |
 | <a name="input_rds_family"></a> [rds\_family](#input\_rds\_family) | Maps the engine version with the parameter group family, a family often covers several versions | `string` | `"postgres10"` | no |
 | <a name="input_rds_name"></a> [rds\_name](#input\_rds\_name) | Optional name of the RDS cluster. Changing the name will re-create the RDS | `string` | `""` | no |
 | <a name="input_replicate_source_db"></a> [replicate\_source\_db](#input\_replicate\_source\_db) | Specifies that this resource is a Replicate database, and to use this value as the source database. This correlates to the identifier of another Amazon RDS Database to replicate. | `string` | `null` | no |

--- a/main.tf
+++ b/main.tf
@@ -126,8 +126,8 @@ resource "aws_db_instance" "rds" {
   snapshot_identifier          = var.snapshot_identifier
   replicate_source_db          = var.replicate_source_db
   auto_minor_version_upgrade   = var.allow_minor_version_upgrade
-  allow_major_version_upgrade  = var.allow_major_version_upgrade
-  parameter_group_name         = aws_db_parameter_group.custom_parameters.name
+  allow_major_version_upgrade  = (var.prepare_for_major_upgrade) ? true : var.allow_major_version_upgrade
+  parameter_group_name         = (var.prepare_for_major_upgrade) ? "default.${var.rds_family}" : aws_db_parameter_group.custom_parameters.name
   ca_cert_identifier           = var.replicate_source_db != null ? null : var.ca_cert_identifier
   performance_insights_enabled = var.performance_insights_enabled
   skip_final_snapshot          = var.skip_final_snapshot
@@ -148,7 +148,7 @@ resource "aws_db_instance" "rds" {
 }
 
 resource "aws_db_parameter_group" "custom_parameters" {
-  name   = local.identifier
+  name   = (var.prepare_for_major_upgrade) ? "${local.identifier}-upgrade" : local.identifier
   family = var.rds_family
 
   dynamic "parameter" {
@@ -160,6 +160,9 @@ resource "aws_db_parameter_group" "custom_parameters" {
     }
   }
 
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "aws_iam_user" "user" {

--- a/variables.tf
+++ b/variables.tf
@@ -212,9 +212,14 @@ variable "vpc_security_group_ids" {
   default     = []
 }
 
-
 variable "db_password_rotated_date" {
   type        = string
   default     = ""
   description = "Using this variable will spin new db password by providing date as value"
+}
+
+variable "prepare_for_major_upgrade" {
+  type        = bool
+  default     = false
+  description = "Set this to true to change your parameter group to the default version, and to turn on the ability to upgrade major versions"
 }


### PR DESCRIPTION
This PR adds a new variable, `prepare_for_major_upgrade`, which when set to true, will change the parameter group to the default for their database; and turn on `allow_major_version_upgrade`.