### PR TITLE
Add the option to override storage class

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ No modules.
 | <a name="input_db_engine"></a> [db\_engine](#input\_db\_engine) | Database engine used e.g. postgres, mysql, sqlserver-ex | `string` | `"postgres"` | no |
 | <a name="input_db_engine_version"></a> [db\_engine\_version](#input\_db\_engine\_version) | The engine version to use e.g. 13.2 for Postgresql, 8.0 for MySQL, 15.00.4073.23.v1 for MS-SQL. Omitting the minor release part allows for automatic updates. | `string` | `"10"` | no |
 | <a name="input_db_instance_class"></a> [db\_instance\_class](#input\_db\_instance\_class) | The instance type of the RDS instance | `string` | `"db.t2.small"` | no |
+| <a name="input_db_storage_class"></a> [db\_storage_class](#input\_db\_storage\_class) | The database storage class ; the module will decide between `gp2` and `io1` based on the IOPS setting, but you can override it to e.g. `gp3` here | `string` | `null` | no |
 | <a name="input_db_iops"></a> [db\_iops](#input\_db\_iops) | The amount of provisioned IOPS. Setting this to a value other than 0 implies a storage\_type of io1 | `number` | `0` | no |
 | <a name="input_db_max_allocated_storage"></a> [db\_max\_allocated\_storage](#input\_db\_max\_allocated\_storage) | Maximum storage limit for storage autoscaling | `string` | `"10000"` | no |
 | <a name="input_db_name"></a> [db\_name](#input\_db\_name) | The name of the database to be created on the instance (if empty, it will be the generated random identifier) | `string` | `""` | no |

--- a/main.tf
+++ b/main.tf
@@ -138,6 +138,11 @@ resource "aws_security_group" "rds-sg" {
   }
 }
 
+locals {
+  iops_led_storage_class = var.db_iops == 0 ? "gp2" : "io1"
+  storage_class          = var.db_storage_class != null ? var.db_storage_class : local.iops_led_storage_class
+}
+
 ###################
 # Create database #
 ###################
@@ -154,7 +159,7 @@ resource "aws_db_instance" "rds" {
   username                     = var.replicate_source_db != null ? null : sensitive("cp${random_string.username.result}")
   password                     = var.replicate_source_db != null ? null : random_password.password.result
   backup_retention_period      = var.db_backup_retention_period
-  storage_type                 = var.db_iops == 0 ? "gp2" : "io1"
+  storage_type                 = local.storage_class
   iops                         = var.db_iops
   storage_encrypted            = can(regex("sqlserver-ex", var.db_engine)) ? false : true
   db_subnet_group_name         = var.replicate_source_db != null ? null : aws_db_subnet_group.db_subnet[0].name

--- a/variables.tf
+++ b/variables.tf
@@ -59,6 +59,12 @@ variable "db_backup_retention_period" {
   type        = string
 }
 
+variable "db_storage_class" {
+  description = "The storage class for the disk. Leave blank if you don't know"
+  default     = null
+  type        = string
+}
+
 variable "db_iops" {
   description = "The amount of provisioned IOPS. Setting this to a value other than 0 implies a storage_type of io1"
   default     = 0


### PR DESCRIPTION
This allows you to make use of newer classes like `gp3` which provide more consistent IOPs at smaller volume sizes (as well as being 20% cheaper).
