### PR TITLE
🐛 Fixing permissions to allow CP Users to list RDS Engine options and engines

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -247,7 +247,8 @@ data "aws_iam_policy_document" "irsa" {
       "rds:DescribeOrderableDBInstanceOptions",
     ]
 
-    resources = "*"
+    resources = ["*",
+    ]
   }
 
   statement {


### PR DESCRIPTION
There is an [issue](https://github.com/ministryofjustice/cloud-platform/issues/5264) where `rds:DescribeDBEngineVersions` and `rds:DescribeOrderableDBInstanceOptions` actions are not working as these are currently within a statement that has the db instance and parameter group as the target resource. These permissions should not be locked to a specific resource for these actions to be invokable.

The PR fixes and allows CP users to run `aws rds describe-db-engine-versions` and `aws rds describe-db-engine-versions`  (shown in the [CP User Guide](https://user-guide.cloud-platform.service.justice.gov.uk/documentation/deploying-an-app/relational-databases/upgrade.html#determining-your-rds-instance-39-s-target-minor-version)) from their pods.