### PR TITLE
refactor: 💡 remove confusing unneeded var

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,6 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_allow_major_version_upgrade"></a> [allow\_major\_version\_upgrade](#input\_allow\_major\_version\_upgrade) | Indicates that major version upgrades are allowed. | `string` | `"false"` | no |
 | <a name="input_allow_minor_version_upgrade"></a> [allow\_minor\_version\_upgrade](#input\_allow\_minor\_version\_upgrade) | Indicates that minor version upgrades are allowed. | `string` | `"true"` | no |
 | <a name="input_application"></a> [application](#input\_application) | Application name | `string` | n/a | yes |
 | <a name="input_backup_window"></a> [backup\_window](#input\_backup\_window) | The daily time range (in UTC) during which automated backups are created if they are enabled. Example: 09:46-10:16 | `string` | `""` | no |

--- a/examples/rds-mariadb.tf
+++ b/examples/rds-mariadb.tf
@@ -12,7 +12,6 @@ module "rds_mariadb" {
 
   # RDS configuration
   allow_minor_version_upgrade  = true
-  allow_major_version_upgrade  = false
   performance_insights_enabled = false
   db_max_allocated_storage     = "500"
   # enable_rds_auto_start_stop   = true # Uncomment to turn off your database overnight between 10PM and 6AM UTC / 11PM and 7AM BST.

--- a/examples/rds-mssql.tf
+++ b/examples/rds-mssql.tf
@@ -12,7 +12,6 @@ module "rds_mssql" {
 
   # RDS configuration
   allow_minor_version_upgrade  = true
-  allow_major_version_upgrade  = false
   performance_insights_enabled = false
   db_max_allocated_storage     = "500"
   # enable_rds_auto_start_stop   = true # Uncomment to turn off your database overnight between 10PM and 6AM UTC / 11PM and 7AM BST.

--- a/examples/rds-mysql.tf
+++ b/examples/rds-mysql.tf
@@ -12,7 +12,6 @@ module "rds_mysql" {
 
   # RDS configuration
   allow_minor_version_upgrade  = true
-  allow_major_version_upgrade  = false
   performance_insights_enabled = false
   db_max_allocated_storage     = "500"
   # enable_rds_auto_start_stop   = true # Uncomment to turn off your database overnight between 10PM and 6AM UTC / 11PM and 7AM BST.

--- a/examples/rds-postgresql.tf
+++ b/examples/rds-postgresql.tf
@@ -12,7 +12,6 @@ module "rds" {
 
   # RDS configuration
   allow_minor_version_upgrade  = true
-  allow_major_version_upgrade  = false
   performance_insights_enabled = false
   db_max_allocated_storage     = "500"
   # enable_rds_auto_start_stop   = true # Uncomment to turn off your database overnight between 10PM and 6AM UTC / 11PM and 7AM BST.
@@ -43,7 +42,7 @@ module "read_replica" {
   count  = 0
   source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=6.0.0"
 
-  vpc_name               = var.vpc_name
+  vpc_name = var.vpc_name
 
   # Tags
   application            = var.application

--- a/main.tf
+++ b/main.tf
@@ -165,7 +165,7 @@ resource "aws_db_instance" "rds" {
   snapshot_identifier          = var.snapshot_identifier
   replicate_source_db          = var.replicate_source_db
   auto_minor_version_upgrade   = var.allow_minor_version_upgrade
-  allow_major_version_upgrade  = (var.prepare_for_major_upgrade) ? true : var.allow_major_version_upgrade
+  allow_major_version_upgrade  = (var.prepare_for_major_upgrade) ? true : false
   parameter_group_name         = (var.prepare_for_major_upgrade) ? "default.${var.rds_family}" : aws_db_parameter_group.custom_parameters.name
   ca_cert_identifier           = var.replicate_source_db != null ? null : var.ca_cert_identifier
   performance_insights_enabled = var.performance_insights_enabled

--- a/variables.tf
+++ b/variables.tf
@@ -77,12 +77,6 @@ variable "allow_minor_version_upgrade" {
   type        = string
 }
 
-variable "allow_major_version_upgrade" {
-  description = "Indicates that major version upgrades are allowed."
-  default     = "false"
-  type        = string
-}
-
 variable "rds_family" {
   description = "Maps the engine version with the parameter group family, a family often covers several versions"
   default     = "postgres10"


### PR DESCRIPTION
- This var isn't needed as there would never be a case where you would have `prepare_for_major_upgrade : false` and `allow_major_version_upgrade: true`