### PR TITLE
Fix version rds-postgresql.tf

### DIFF
--- a/examples/rds-postgresql.tf
+++ b/examples/rds-postgresql.tf
@@ -41,7 +41,7 @@ module "rds" {
 module "read_replica" {
   # default off
   count  = 0
-  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=6.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=6.0.2"
 
   vpc_name               = var.vpc_name
 


### PR DESCRIPTION
Fixes an error I got when using this file as a template: https://github.com/ministryofjustice/cloud-platform-environments/actions/runs/8817117259/job/24202735764?pr=22661

I guess this one was missed whenever the version was bumped