### PR TITLE
feat: Update ca cert identifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ No modules.
 | <a name="input_application"></a> [application](#input\_application) | Application name | `string` | n/a | yes |
 | <a name="input_backup_window"></a> [backup\_window](#input\_backup\_window) | The daily time range (in UTC) during which automated backups are created if they are enabled. Example: 09:46-10:16 | `string` | `""` | no |
 | <a name="input_business_unit"></a> [business\_unit](#input\_business\_unit) | Area of the MOJ responsible for the service | `string` | n/a | yes |
-| <a name="input_ca_cert_identifier"></a> [ca\_cert\_identifier](#input\_ca\_cert\_identifier) | Specifies the identifier of the CA certificate for the DB instance | `string` | `"rds-ca-2019"` | no |
+| <a name="input_ca_cert_identifier"></a> [ca\_cert\_identifier](#input\_ca\_cert\_identifier) | Specifies the identifier of the CA certificate for the DB instance | `string` | `"rds-ca-rsa2048-g1"` | no |
 | <a name="input_character_set_name"></a> [character\_set\_name](#input\_character\_set\_name) | DB char set, used only by MS-SQL | `string` | `"SQL_Latin1_General_CP1_CI_AS"` | no |
 | <a name="input_db_allocated_storage"></a> [db\_allocated\_storage](#input\_db\_allocated\_storage) | The allocated storage in gibibytes | `string` | `"10"` | no |
 | <a name="input_db_backup_retention_period"></a> [db\_backup\_retention\_period](#input\_db\_backup\_retention\_period) | The days to retain backups. Must be 1 or greater to be a source for a Read Replica | `string` | `"7"` | no |

--- a/variables.tf
+++ b/variables.tf
@@ -91,7 +91,7 @@ variable "rds_family" {
 
 variable "ca_cert_identifier" {
   description = "Specifies the identifier of the CA certificate for the DB instance"
-  default     = "rds-ca-2019"
+  default     = "rds-ca-rsa2048-g1"
   type        = string
 }
 


### PR DESCRIPTION
This PR is to update the RDS instance default `rds-ca-2019` CA certificate which is expiring on **22/08/24** to to the new Amazon RDS cert `rds-ca-rsa2048-g1` which is valid for 40 year.

Relates to ministryofjustice/cloud-platform#5469