### PR TITLE
chore: 🤖 fix conditional check for replica db name and engine version

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -148,9 +148,9 @@ resource "aws_db_instance" "rds" {
   max_allocated_storage        = var.db_max_allocated_storage
   apply_immediately            = true
   engine                       = var.replicate_source_db == null ? var.db_engine : null
-  engine_version               = var.replicate_source_db == null ? var.db_engine_version : null
+  engine_version               = var.db_engine_version
   instance_class               = var.db_instance_class
-  db_name                      = can(regex("sqlserver", var.db_engine)) ? null : local.db_name
+  db_name                      = var.replicate_source_db != null || can(regex("sqlserver", var.db_engine)) ? null : local.db_name
   username                     = var.replicate_source_db != null ? null : sensitive("cp${random_string.username.result}")
   password                     = var.replicate_source_db != null ? null : random_password.password.result
   backup_retention_period      = var.db_backup_retention_period


### PR DESCRIPTION
Relates to ministryofjustice/cloud-platform#6068

This PR updates our RDS module to reflect changes that were made to the AWS provider in `4.63` concerning re-enabling engine version setting for read replicas:
https://github.com/hashicorp/terraform-provider-aws/issues/24887

This is necessary for CP users who are manually (not auto minor upgrading) their RDS configurations where they have a primary and a replica.

In this case the user _must_ be able to set the minor version for their replica and carry out this prior to completing the minor version upgrade of their primary RDS.
