### PR TITLE
Add AddTagsToResource to fix issue with CreateDBSnapshot

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -284,6 +284,7 @@ data "aws_iam_policy_document" "irsa" {
     sid    = "AllowRDSAccessFor${random_id.id.hex}"
     effect = "Allow"
     actions = [
+      "rds:AddTagsToResource",
       "rds:CopyDBSnapshot",
       "rds:CreateDBSnapshot",
       "rds:DeleteDBSnapshot",


### PR DESCRIPTION
This adds permission to the RDS irsa to add tags which is required when CreateDBSnapshot is used. 
The tags from the RDS are automatically added to the snapshot so this process fails without these permissions:
`An error occurred (AccessDenied) when calling the CreateDBSnapshot operation: {user} is not authorized to perform: rds:AddTagsToResource on {rds arn} because no identity-based policy allows the rds:AddTagsToResource action`