### PR TITLE
Fix Postgres Log Generation Issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ Instructions on how to do this are available [here](https://user-guide.cloud-pla
 
 ## Enabling Logging to XSIAM Cortex
 
-If you are required to stream logs to XSIAM Cortex for security auditing, you can do so by setting `opt_in_xsiam_logging` variable to true. In the case of mysql and mariadb engines, you will need to create an option group, set the MARIADB_AUDIT_PLUGIN option, and pass it into the module call. Please see the '/examples' folder.
+If you are required to stream logs to XSIAM Cortex for security auditing, you can do so by setting `opt_in_xsiam_logging` variable to true. NOTE: IN THE CASE OF MYSQL AND MARIADB ENGINES, THIS FUNCTIONALITY IS TEMPORARILY DISABLED AND WILL BE ENABLED AGAIN SOON.
 
 ## IMPORTANT - Release 9.0.0 changes:
 
@@ -226,8 +226,8 @@ No modules.
 | <a name="input_license_model"></a> [license\_model](#input\_license\_model) | License model information for this DB instance, options for MS-SQL are: license-included \| bring-your-own-license \| general-public-license | `string` | `null` | no |
 | <a name="input_maintenance_window"></a> [maintenance\_window](#input\_maintenance\_window) | The window to perform maintenance in. Syntax: 'ddd:hh24:mi-ddd:hh24:mi'. Eg: 'Mon:00:00-Mon:03:00' | `string` | `null` | no |
 | <a name="input_namespace"></a> [namespace](#input\_namespace) | Namespace name | `string` | n/a | yes |
-| <a name="input_opt_in_xsiam_logging"></a> [opt\_in\_xsiam\_logging](#input\_opt\_in\_xsiam\_logging) | If set to true, it will create Cloudwatch log groups for the RDS instance and send them to Cortex XSIAM. NOTE: for MySQL and MariaDB engines, you must pass in an option group with MARIADB\_AUDIT\_PLUGIN set as an option | `bool` | `false` | no |
-| <a name="input_option_group_name"></a> [option\_group\_name](#input\_option\_group\_name) | (Optional) The name of an 'aws\_db\_option\_group' to associate to the DB instance. This must be provided with the MARIADB\_AUDIT\_PLUGIN option set, if you enable opt\_in\_xsiam\_logging for MySQL or MariaDB engines. | `string` | `null` | no |
+| <a name="input_opt_in_xsiam_logging"></a> [opt\_in\_xsiam\_logging](#input\_opt\_in\_xsiam\_logging) | If set to true, it will create Cloudwatch log groups for the RDS instance and send them to Cortex XSIAM. | `bool` | `false` | no |
+| <a name="input_option_group_name"></a> [option\_group\_name](#input\_option\_group\_name) | (Optional) The name of an 'aws\_db\_option\_group' to associate to the DB instance. | `string` | `null` | no |
 | <a name="input_performance_insights_enabled"></a> [performance\_insights\_enabled](#input\_performance\_insights\_enabled) | Enable performance insights for RDS? Note: the user should ensure insights are disabled once the desired outcome is achieved. | `bool` | `false` | no |
 | <a name="input_prepare_for_major_upgrade"></a> [prepare\_for\_major\_upgrade](#input\_prepare\_for\_major\_upgrade) | Set this to true to change your parameter group to the default version, and to turn on the ability to upgrade major versions | `bool` | `false` | no |
 | <a name="input_rds_family"></a> [rds\_family](#input\_rds\_family) | Maps the engine version with the parameter group family, a family often covers several versions | `string` | `"postgres10"` | no |

--- a/examples/rds-mariadb.tf
+++ b/examples/rds-mariadb.tf
@@ -38,11 +38,6 @@ module "rds_mariadb" {
   # uncomment below:
 
   # enable_irsa = true
-
-  # If you want to enable Cloudwatch logging for this mariadb RDS instance, uncomment below:
-  # opt_in_xsiam_logging = true
-  # option_group_name    = aws_db_option_group.rds_mariadb_og.name
-
 }
 
 resource "kubernetes_secret" "rds_mariadb" {
@@ -58,19 +53,3 @@ resource "kubernetes_secret" "rds_mariadb" {
     rds_instance_address  = module.rds_mariadb.rds_instance_address
   }
 }
-
-# resource "aws_db_option_group" "rds_mariadb_og" {
-#   name                     = "test-mariadb-option-group"
-#   option_group_description = "MariaDB option group for logging"
-#   engine_name              = "mariadb"
-#   major_engine_version     = "10.6"
-
-#   option {
-#     option_name = "MARIADB_AUDIT_PLUGIN"
-
-#     option_settings {
-#       name  = "SERVER_AUDIT_EVENTS"
-#       value = "CONNECT,QUERY_DDL,QUERY_DCL" // DO NOT CHANGE THESE 'MARIADB_AUDIT_PLUGIN' SETTING VALUES WITHOUT CONSULTING MOJ CLOUD PLATFORM TEAM
-#     }
-#   }
-# }

--- a/examples/rds-mariadb.tf
+++ b/examples/rds-mariadb.tf
@@ -67,5 +67,10 @@ resource "kubernetes_secret" "rds_mariadb" {
 
 #   option {
 #     option_name = "MARIADB_AUDIT_PLUGIN"
+
+#     option_settings {
+#       name  = "SERVER_AUDIT_EVENTS"
+#       value = "CONNECT,QUERY_DDL,QUERY_DCL" // DO NOT CHANGE THESE 'MARIADB_AUDIT_PLUGIN' SETTING VALUES WITHOUT CONSULTING MOJ CLOUD PLATFORM TEAM
+#     }
 #   }
 # }

--- a/examples/rds-mysql.tf
+++ b/examples/rds-mysql.tf
@@ -38,10 +38,6 @@ module "rds_mysql" {
   # uncomment below:
 
   # enable_irsa = true
-
-  # If you want to enable Cloudwatch logging for this mysql RDS instance, uncomment this and the option group below:
-  # opt_in_xsiam_logging = true
-  # option_group_name    = aws_db_option_group.rds_mysql_og.name
 }
 
 resource "kubernetes_secret" "rds_mysql" {
@@ -70,19 +66,3 @@ resource "kubernetes_config_map" "rds_mysql" {
     db_identifier = module.rds_mysql.db_identifier
   }
 }
-
-# resource "aws_db_option_group" "rds_mysql_og" {
-#   name                     = "test-mysql-option-group"
-#   option_group_description = "MySQL option group for logging"
-#   engine_name              = "mysql"
-#   major_engine_version     = "8.0"
-
-#   option {
-#     option_name = "MARIADB_AUDIT_PLUGIN"
-
-#     option_settings {
-#       name  = "SERVER_AUDIT_EVENTS"
-#       value = "CONNECT,QUERY_DDL,QUERY_DCL" // DO NOT CHANGE THESE 'MARIADB_AUDIT_PLUGIN' SETTING VALUES WITHOUT CONSULTING MOJ CLOUD PLATFORM TEAM
-#     }
-#   }
-# }

--- a/examples/rds-mysql.tf
+++ b/examples/rds-mysql.tf
@@ -79,5 +79,10 @@ resource "kubernetes_config_map" "rds_mysql" {
 
 #   option {
 #     option_name = "MARIADB_AUDIT_PLUGIN"
+
+#     option_settings {
+#       name  = "SERVER_AUDIT_EVENTS"
+#       value = "CONNECT,QUERY_DDL,QUERY_DCL" // DO NOT CHANGE THESE 'MARIADB_AUDIT_PLUGIN' SETTING VALUES WITHOUT CONSULTING MOJ CLOUD PLATFORM TEAM
+#     }
 #   }
 # }

--- a/examples/rds-postgresql.tf
+++ b/examples/rds-postgresql.tf
@@ -20,7 +20,7 @@ module "rds" {
 
   # PostgreSQL specifics
   db_engine         = "postgres"
-  db_engine_version = "16"   # If you are managing minor version updates, refer to user guide: https://user-guide.cloud-platform.service.justice.gov.uk/documentation/deploying-an-app/relational-databases/upgrade.html#upgrading-a-database-version-or-changing-the-instance-type
+  db_engine_version = "16" # If you are managing minor version updates, refer to user guide: https://user-guide.cloud-platform.service.justice.gov.uk/documentation/deploying-an-app/relational-databases/upgrade.html#upgrading-a-database-version-or-changing-the-instance-type
   rds_family        = "postgres16"
   db_instance_class = "db.t4g.micro"
 
@@ -51,7 +51,7 @@ module "read_replica" {
   count  = 0
   source = "github.com/ministryofjustice/cloud-platform-terraform-rds-instance?ref=7.3.0"
 
-  vpc_name               = var.vpc_name
+  vpc_name = var.vpc_name
 
   # Tags
   application            = var.application
@@ -67,7 +67,7 @@ module "read_replica" {
 
   # PostgreSQL specifics
   db_engine         = "postgres"
-  db_engine_version = "16"   # If you are managing minor version updates, refer to user guide: https://user-guide.cloud-platform.service.justice.gov.uk/documentation/deploying-an-app/relational-databases/upgrade.html#upgrading-a-database-version-or-changing-the-instance-type
+  db_engine_version = "16" # If you are managing minor version updates, refer to user guide: https://user-guide.cloud-platform.service.justice.gov.uk/documentation/deploying-an-app/relational-databases/upgrade.html#upgrading-a-database-version-or-changing-the-instance-type
   rds_family        = "postgres16"
   db_instance_class = "db.t4g.micro"
   # It is mandatory to set the below values to create read replica instance

--- a/main.tf
+++ b/main.tf
@@ -42,8 +42,47 @@ locals {
     }
   ] : []
 
+  required_postgres_logging_parameters = var.opt_in_xsiam_logging && var.db_engine == "postgres" ? [
+    {
+      name         = "shared_preload_libraries"
+      value        = "pgaudit"
+      apply_method = "pending-reboot"
+    },
+    {
+      name         = "pgaudit.log"
+      value        = "ddl, role"
+      apply_method = "immediate"
+    },
+    {
+      name         = "log_connections"
+      value        = "1"
+      apply_method = "immediate"
+    },
+      {
+      name         = "log_disconnections"
+      value        = "1"
+      apply_method = "immediate"
+    },
+    {
+      name         = "log_min_error_statement"
+      value        = "panic"
+      apply_method = "immediate"
+    },
+    {
+      name         = "log_error_verbosity"
+      value        = "terse"
+      apply_method = "immediate"
+    },
+    {
+      name         = "log_statement"
+      value        = "none"
+      apply_method = "immediate"
+    }
+  ] : []
+
   all_db_parameters = concat(
     local.required_logging_parameters,
+    local.required_postgres_logging_parameters,
     var.db_parameter
   )
 

--- a/main.tf
+++ b/main.tf
@@ -144,7 +144,7 @@ resource "null_resource" "validate_mysql_audit_option_group" {
       fi
 
       # Normalize (lowercase, no spaces, sort) and compare
-      EVENTS_NORM=$(echo "$EVENTS_VALUE" | tr '[:upper:]' '[:lower:]' | tr -d ' ' | tr ',' '\n' | sort | paste -s -d,)
+      EVENTS_NORM=$(echo "$EVENTS_VALUE" | tr '[:upper:]' '[:lower:]' | tr -d ' ' | tr ',' '\n' | sort | tr '\n' ',' | sed 's/,$//')
       EXPECTED="connect,query_dcl,query_ddl"
 
       if [ "$EVENTS_NORM" != "$EXPECTED" ]; then

--- a/main.tf
+++ b/main.tf
@@ -144,7 +144,7 @@ resource "null_resource" "validate_mysql_audit_option_group" {
       fi
 
       # Normalize (lowercase, no spaces, sort) and compare
-      EVENTS_NORM=$(echo "$EVENTS_VALUE" | tr '[:upper:]' '[:lower:]' | tr -d ' ' | tr ',' '\n' | sort | paste -s -d ',')
+      EVENTS_NORM=$(echo "$EVENTS_VALUE" | tr '[:upper:]' '[:lower:]' | tr -d ' ' | tr ',' '\n' | sort | paste -s -d,)
       EXPECTED="connect,query_dcl,query_ddl"
 
       if [ "$EVENTS_NORM" != "$EXPECTED" ]; then

--- a/main.tf
+++ b/main.tf
@@ -195,8 +195,8 @@ data "external" "validate_mysql_audit_option_group" {
       exit 1
     fi
 
-    # Normalize (lowercase, no spaces, sort) and compare
-    EVENTS_NORM=$(echo "$EVENTS_VALUE" | tr -d '[:space:]' | tr '[:upper:]' '[:lower:]' | tr ',' '\n' | sort -u | tr '\n' ',' | sed 's/,$//')
+    # Normalize (lowercase, no spaces, sort) and compare - do NOT dedupe with -u
+    EVENTS_NORM=$(echo "$EVENTS_VALUE" | tr -d '[:space:]' | tr '[:upper:]' '[:lower:]' | tr ',' '\n' | sort | tr '\n' ',' | sed 's/,$//')
     EXPECTED="connect,query_dcl,query_ddl"
 
     if [ "$EVENTS_NORM" != "$EXPECTED" ]; then

--- a/main.tf
+++ b/main.tf
@@ -12,8 +12,8 @@ locals {
   # engine-to-export log configuration mappings
   db_log_export_mappings = {
     postgres      = ["postgresql", "upgrade"]
-    mysql         = ["audit", "error", "general", "slowquery"]
-    mariadb       = ["audit", "error", "general", "slowquery"]
+    mysql         = ["audit", "error"]
+    mariadb       = ["audit", "error"]
     sqlserver-ee  = ["agent", "error"]
     sqlserver-se  = ["agent", "error"]
     sqlserver-ex  = ["agent", "error"]
@@ -27,12 +27,7 @@ locals {
   required_logging_parameters = var.opt_in_xsiam_logging && contains(["mysql", "mariadb"], var.db_engine) ? [
     {
       name         = "general_log"
-      value        = "1"
-      apply_method = "immediate"
-    },
-    {
-      name         = var.db_engine == "mysql" ? "slow_query_log" : "log_slow_query"
-      value        = "1"
+      value        = "0"
       apply_method = "immediate"
     },
     {
@@ -80,9 +75,18 @@ locals {
     }
   ] : []
 
+  required_oracle_logging_parameters = var.opt_in_xsiam_logging && var.db_engine == "oracle-se2" ? [
+    {
+      name         = "audit_trail"
+      value        = "DB"
+      apply_method = "pending-reboot"
+    }
+  ] : []
+
   all_db_parameters = concat(
     local.required_logging_parameters,
     local.required_postgres_logging_parameters,
+    local.required_oracle_logging_parameters,
     var.db_parameter
   )
 

--- a/main.tf
+++ b/main.tf
@@ -144,7 +144,7 @@ resource "null_resource" "validate_mysql_audit_option_group" {
       fi
 
       # Normalize (lowercase, no spaces, sort) and compare
-      EVENTS_NORM=$(echo "$EVENTS_VALUE" | tr '[:upper:]' '[:lower:]' | tr -d ' ' | tr ',' '\n' | sort | tr '\n' ',' | sed 's/,$//')
+      EVENTS_NORM=$(echo "$EVENTS_VALUE" | tr -d '[:space:]' | tr '[:upper:]' '[:lower:]' | tr ',' '\n' | sort -u | tr '\n' ',' | sed 's/,$//')
       EXPECTED="connect,query_dcl,query_ddl"
 
       if [ "$EVENTS_NORM" != "$EXPECTED" ]; then

--- a/variables.tf
+++ b/variables.tf
@@ -181,7 +181,7 @@ variable "character_set_name" {
 
 variable "option_group_name" {
   type        = string
-  description = "(Optional) The name of an 'aws_db_option_group' to associate to the DB instance. This must be provided with the MARIADB_AUDIT_PLUGIN option set, if you enable opt_in_xsiam_logging for MySQL or MariaDB engines."
+  description = "(Optional) The name of an 'aws_db_option_group' to associate to the DB instance."
   default     = null
 }
 
@@ -216,7 +216,7 @@ variable "enable_irsa" {
 # Logging #
 ###########
 variable "opt_in_xsiam_logging" {
-  description = "If set to true, it will create Cloudwatch log groups for the RDS instance and send them to Cortex XSIAM. NOTE: for MySQL and MariaDB engines, you must pass in an option group with MARIADB_AUDIT_PLUGIN set as an option"
+  description = "If set to true, it will create Cloudwatch log groups for the RDS instance and send them to Cortex XSIAM."
   type        = bool
   default     = false
 }


### PR DESCRIPTION
- Added Audit param (ddl, role) and other necessary fields for more holistic logging (connections, disconnections etc).
- Set postgres error statements to 'panic' and 'verbosity' to terse (to avoid data leaks where errors occur).
- Removed risky or not-required log-groups.
- Temporarily disabled logging for mysql/mariadb. REASON: More validation is required when users pass in option_groups to avoid audit config values that may leak data (once script for this is written, will re-enable).